### PR TITLE
Add source tracking for books from manifest

### DIFF
--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/core/models/Book.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/core/models/Book.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
  * @property id The unique identifier of the book
  * @property categoryId The identifier of the category this book belongs to
  * @property title The title of the book
+ * @property sourceId The identifier of the source this book originates from
  * @property authors The list of authors of this book
  * @property topics The list of topics associated with this book
  * @property pubPlaces The list of publication places for this book
@@ -20,6 +21,7 @@ import kotlinx.serialization.Serializable
 data class Book(
     val id: Long = 0,
     val categoryId: Long,
+    val sourceId: Long,
     val title: String,
     val authors: List<Author> = emptyList(),
     val topics: List<Topic> = emptyList(),

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/core/models/Source.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/core/models/Source.kt
@@ -1,0 +1,13 @@
+package io.github.kdroidfilter.seforimlibrary.core.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a content source/provider entry.
+ */
+@Serializable
+data class Source(
+    val id: Long = 0,
+    val name: String
+)
+

--- a/dao/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/dao/extensions/ModelExtensions.kt
+++ b/dao/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/dao/extensions/ModelExtensions.kt
@@ -10,6 +10,7 @@ import io.github.kdroidfilter.seforimlibrary.core.models.PubDate
 import io.github.kdroidfilter.seforimlibrary.core.models.PubPlace
 import io.github.kdroidfilter.seforimlibrary.core.models.SearchResult
 import io.github.kdroidfilter.seforimlibrary.core.models.TocEntry
+import io.github.kdroidfilter.seforimlibrary.core.models.Source
 import io.github.kdroidfilter.seforimlibrary.core.models.Topic
 // Legacy FTS result types removed (Lucene now used at app layer)
 import kotlinx.serialization.json.Json
@@ -72,6 +73,7 @@ fun io.github.kdroidfilter.seforimlibrary.db.Book.toModel(json: Json, authors: L
     return Book(
         id = id,
         categoryId = categoryId,
+        sourceId = sourceId,
         title = title,
         authors = authors,
         topics = emptyList(),
@@ -87,6 +89,16 @@ fun io.github.kdroidfilter.seforimlibrary.db.Book.toModel(json: Json, authors: L
         hasCommentaryConnection = hasCommentaryConnection == 1L,
         hasOtherConnection = hasOtherConnection == 1L
 
+    )
+}
+
+/**
+ * Converts a database Source entity to a domain Source model.
+ */
+fun io.github.kdroidfilter.seforimlibrary.db.Source.toModel(): Source {
+    return Source(
+        id = id,
+        name = name
     )
 }
 

--- a/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/BookQueries.sq
+++ b/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/BookQueries.sq
@@ -37,12 +37,12 @@ selectBaseIds:
 SELECT id FROM book WHERE isBaseBook = 1 ORDER BY orderIndex, title;
 
 insert:
-INSERT INTO book (categoryId, title, heShortDesc, notesContent, orderIndex, totalLines, isBaseBook)
-VALUES (?, ?, ?, ?, ?, ?, ?);
+INSERT INTO book (categoryId, sourceId, title, heShortDesc, notesContent, orderIndex, totalLines, isBaseBook)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 
 insertWithId:
-INSERT INTO book (id, categoryId, title, heShortDesc, notesContent, orderIndex, totalLines, isBaseBook)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO book (id, categoryId, sourceId, title, heShortDesc, notesContent, orderIndex, totalLines, isBaseBook)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateTotalLines:
 UPDATE book SET totalLines = ? WHERE id = ?;

--- a/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/Database.sq
+++ b/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/Database.sq
@@ -53,10 +53,19 @@ CREATE TABLE IF NOT EXISTS pub_date (
 
 CREATE INDEX IF NOT EXISTS idx_pub_date_date ON pub_date(date);
 
+-- Sources table (origin of each book)
+CREATE TABLE IF NOT EXISTS source (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_source_name ON source(name);
+
 -- Books table
 CREATE TABLE IF NOT EXISTS book (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     categoryId INTEGER NOT NULL,
+    sourceId INTEGER NOT NULL,
     title TEXT NOT NULL,
     heShortDesc TEXT,
     -- Optional raw notes attached to the base book (when a companion file 'הערות על <title>' exists)
@@ -68,12 +77,14 @@ CREATE TABLE IF NOT EXISTS book (
     hasReferenceConnection INTEGER NOT NULL DEFAULT 0,
     hasCommentaryConnection INTEGER NOT NULL DEFAULT 0,
     hasOtherConnection INTEGER NOT NULL DEFAULT 0,
-    FOREIGN KEY (categoryId) REFERENCES category(id) ON DELETE CASCADE
+    FOREIGN KEY (categoryId) REFERENCES category(id) ON DELETE CASCADE,
+    FOREIGN KEY (sourceId) REFERENCES source(id) ON DELETE RESTRICT
 );
 
 CREATE INDEX IF NOT EXISTS idx_book_category ON book(categoryId);
 CREATE INDEX IF NOT EXISTS idx_book_title ON book(title);
 CREATE INDEX IF NOT EXISTS idx_book_order ON book(orderIndex);
+CREATE INDEX IF NOT EXISTS idx_book_source ON book(sourceId);
 
 -- Book-publication place junction table
 CREATE TABLE IF NOT EXISTS book_pub_place (

--- a/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/SourceQueries.sq
+++ b/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/SourceQueries.sq
@@ -1,0 +1,17 @@
+-- Source queries
+
+selectAll:
+SELECT * FROM source ORDER BY name;
+
+selectById:
+SELECT * FROM source WHERE id = ?;
+
+selectByName:
+SELECT * FROM source WHERE name = ? LIMIT 1;
+
+insert:
+INSERT INTO source (name) VALUES (?);
+
+lastInsertRowId:
+SELECT last_insert_rowid();
+


### PR DESCRIPTION
### Description

This pull request introduces source tracking for books by integrating source data processed from `files_manifest.json`. Key changes include:

- Creation of a `Source` model and database schema updates.
- Integration of source references in the `book` table.
- Persistence of source information during book processing.
- Adjustments to queries, models, and persistence layers to ensure source linkage.

These updates enhance the system's capability to track and manage the origin of content.