### PR TITLE
Implement source blacklisting functionality

### DIFF
--- a/generator/src/commonMain/resources/source-blacklist.txt
+++ b/generator/src/commonMain/resources/source-blacklist.txt
@@ -1,0 +1,1 @@
+wiki_jewish_books


### PR DESCRIPTION
This pull request introduces a feature to blacklist specific content origins during processing. Key changes include:

- Addition of `source-blacklist.txt` for listing blacklisted sources.
- Enhanced `Generator` to filter and skip blacklisted sources during preloading and processing.
- Integration of logging to indicate skipped sources due to blacklisting.
-