### PR TITLE
Improve folder removal

### DIFF
--- a/generator/src/commonMain/resources/otzaria-folder-to-remove.txt
+++ b/generator/src/commonMain/resources/otzaria-folder-to-remove.txt
@@ -1,0 +1,6 @@
+# One folder per line (under אוצריא/)
+# These folders will be removed after extraction of the Otzaria source
+אודות התוכנה
+אודות על התוכנה
+הודעה חשובה
+


### PR DESCRIPTION
Refactored the mechanism for removing unwanted Otzaria folders to utilize dynamic configuration:

- Replaced hardcoded logic with a resource-based approach, reading folders to be removed from `otzaria-folder-to-remove.txt`.
- Added resource file to define folders, enabling flexibility and easier updates.
- Enhanced logging for scenarios where resource files are missing or fail to load.