### PR TITLE
Add release information creation and integration

### DIFF
--- a/.github/workflows/manual-generate-release.yml
+++ b/.github/workflows/manual-generate-release.yml
@@ -56,6 +56,17 @@ jobs:
       - name: buildLuceneIndexDefault
         run: ./gradlew :generator:buildLuceneIndexDefault --no-daemon --stacktrace
 
+      - name: Compute tag name (UTC) for release info
+        id: release_meta
+        shell: bash
+        run: |
+          TAG=$(date -u +"%Y%m%d%H%M%S")
+          echo "release_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Computed release tag: ${TAG}"
+
+      - name: writeReleaseInfo
+        run: ./gradlew :generator:writeReleaseInfo -PreleaseName=${{ steps.release_meta.outputs.release_tag }} --no-daemon --stacktrace
+
       - name: packageArtifacts
         run: ./gradlew :generator:packageArtifacts --no-daemon --stacktrace
 
@@ -76,19 +87,11 @@ jobs:
           echo "Found ${#PARTS[@]} part file(s):"
           ls -lh "${PARTS[@]}"
 
-      - name: Compute tag name (UTC)
-        id: meta
-        shell: bash
-        run: |
-          TAG=$(date -u +"%Y%m%d%H%M%S")
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Computed tag: ${TAG}"
-
       - name: Create GitHub Release and upload assets
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.tag }}
+          tag_name: ${{ steps.release_meta.outputs.release_tag }}
+          name: ${{ steps.release_meta.outputs.release_tag }}
           draft: false
           prerelease: false
           files: |

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -72,9 +72,9 @@ tasks.register<JavaExec>("downloadOtzaria") {
 // Package DB + Lucene indexes into single tar.zst and split
 tasks.register<JavaExec>("packageArtifacts") {
     group = "application"
-    description = "Create seforim_bundle.tar.zst (DB + indexes) with zstd and split into ~1.9GiB parts."
+    description = "Create seforim_bundle.tar.zst (DB + indexes + release info) with zstd and split into ~1.9GiB parts."
 
-    dependsOn("jvmJar")
+    dependsOn("jvmJar", "writeReleaseInfo")
     mainClass.set("io.github.kdroidfilter.seforimlibrary.generator.PackageArtifactsKt")
     classpath = files(tasks.named("jvmJar")) + configurations.getByName("jvmRuntimeClasspath")
 
@@ -253,4 +253,24 @@ tasks.register<JavaExec>("buildCatalog") {
     args(dbPath)
 
     jvmArgs = listOf("-Xmx2g")
+}
+
+// Write release information to release_info.txt file
+// Usage:
+//   ./gradlew :generator:writeReleaseInfo
+//   ./gradlew :generator:writeReleaseInfo -PreleaseName=20251108195010
+tasks.register<JavaExec>("writeReleaseInfo") {
+    group = "application"
+    description = "Write release information (timestamp) to release_info.txt file."
+
+    dependsOn("jvmJar")
+    mainClass.set("io.github.kdroidfilter.seforimlibrary.generator.WriteReleaseInfoKt")
+    classpath = files(tasks.named("jvmJar")) + configurations.getByName("jvmRuntimeClasspath")
+
+    // Pass release name if provided
+    if (project.hasProperty("releaseName")) {
+        systemProperty("releaseName", project.property("releaseName") as String)
+    }
+
+    jvmArgs = listOf("-Xmx256m")
 }

--- a/generator/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/generator/PackageArtifacts.kt
+++ b/generator/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/generator/PackageArtifacts.kt
@@ -62,6 +62,9 @@ fun main(args: Array<String>) {
 
     // Resolve precomputed catalog next to the DB
     val catalogPath: Path = dbPath.resolveSibling("catalog.pb")
+    
+    // Resolve release info file in build directory
+    val releaseInfoPath: Path = Paths.get("build", "release_info.txt")
 
     if (!textIndexDir.toFile().isDirectory) {
         logger.w { "Lucene text index directory missing: $textIndexDir (will skip)" }
@@ -71,6 +74,9 @@ fun main(args: Array<String>) {
     }
     if (!catalogPath.exists()) {
         logger.w { "Precomputed catalog missing: $catalogPath (will skip)" }
+    }
+    if (!releaseInfoPath.exists()) {
+        logger.w { "Release info file missing: $releaseInfoPath (will skip)" }
     }
 
     // Output: single bundle tar.zst
@@ -109,6 +115,7 @@ fun main(args: Array<String>) {
         "Packaging into single bundle:\n" +
             " - DB: $dbPath\n" +
             " - Catalog: $catalogPath\n" +
+            " - Release info: $releaseInfoPath\n" +
             " - Text index: $textIndexDir\n" +
             " - Lookup index: $lookupIndexDir\n" +
             " -> Bundle .tar.zst: $bundleOutputPath\n" +
@@ -129,6 +136,7 @@ fun main(args: Array<String>) {
                         val haveText = textIndexDir.toFile().isDirectory
                         val haveLookup = lookupIndexDir.toFile().isDirectory
                         val haveCatalog = catalogPath.exists()
+                        val haveReleaseInfo = releaseInfoPath.exists()
 
                         if (haveLookup) {
                             addDirectoryToTar(tar, lookupIndexDir, lookupIndexDir.fileName.toString(), logger)
@@ -150,6 +158,14 @@ fun main(args: Array<String>) {
                             logger.i { "Added precomputed catalog to bundle" }
                         } else {
                             logger.w { "Precomputed catalog missing: $catalogPath (skipped)" }
+                        }
+                        
+                        // Add the release info file if available
+                        if (haveReleaseInfo) {
+                            addFileToTar(tar, releaseInfoPath, releaseInfoPath.fileName.toString(), logger)
+                            logger.i { "Added release info to bundle" }
+                        } else {
+                            logger.w { "Release info file missing: $releaseInfoPath (skipped)" }
                         }
 
                         tar.finish()

--- a/generator/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/generator/WriteReleaseInfo.kt
+++ b/generator/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/generator/WriteReleaseInfo.kt
@@ -1,0 +1,49 @@
+package io.github.kdroidfilter.seforimlibrary.generator
+
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.system.exitProcess
+
+/**
+ * Write release information to a release_info.txt file.
+ * The release name follows the format used in CI: yyyyMMddHHmmss (UTC).
+ *
+ * Usage:
+ *   ./gradlew -p SeforimLibrary :generator:writeReleaseInfo
+ *   or with custom release name:
+ *   ./gradlew -p SeforimLibrary :generator:writeReleaseInfo -PreleaseName=20251108195010
+ *
+ * Output:
+ *   Creates release_info.txt in generator/build/ directory containing the release name
+ */
+fun main(args: Array<String>) {
+    Logger.setMinSeverity(Severity.Info)
+    val logger = Logger.withTag("WriteReleaseInfo")
+
+    // Get release name from property or generate current UTC timestamp
+    val releaseName = System.getProperty("releaseName")
+        ?: ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
+
+    // Output path: generator/build/release_info.txt
+    val outputPath = Paths.get("build", "release_info.txt")
+    
+    try {
+        // Ensure build directory exists
+        Files.createDirectories(outputPath.parent)
+        
+        // Write release name to file
+        Files.writeString(outputPath, releaseName)
+        
+        logger.i { "Release info written to $outputPath: $releaseName" }
+        println("Release: $releaseName")
+        
+    } catch (e: Exception) {
+        logger.e(e) { "Failed to write release info to $outputPath" }
+        exitProcess(1)
+    }
+}


### PR DESCRIPTION
Enhance the build process by introducing the `writeReleaseInfo` task to generate release metadata with a timestamp. Updated workflows compute a UTC-based release tag for consistency and the generated `release_info.txt` is integrated into the artifact bundling process. These changes ensure better traceability and standardization across builds and releases.