### PR TITLE
refactor: make search pipeline suspend-aware

### DIFF
--- a/cli/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/cli/CliSnippetProvider.kt
+++ b/cli/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/cli/CliSnippetProvider.kt
@@ -3,7 +3,8 @@ package io.github.kdroidfilter.seforimlibrary.cli
 import io.github.kdroidfilter.seforimlibrary.dao.repository.SeforimRepository
 import io.github.kdroidfilter.seforimlibrary.search.LineSnippetInfo
 import io.github.kdroidfilter.seforimlibrary.search.SnippetProvider
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jsoup.Jsoup
 import org.jsoup.safety.Safelist
 
@@ -18,10 +19,10 @@ class CliSnippetProvider(
         private const val SNIPPET_MIN_LENGTH = 280
     }
 
-    override fun getSnippetSources(lines: List<LineSnippetInfo>): Map<Long, String> {
+    override suspend fun getSnippetSources(lines: List<LineSnippetInfo>): Map<Long, String> {
         if (lines.isEmpty()) return emptyMap()
 
-        return runBlocking {
+        return withContext(Dispatchers.IO) {
             val byBook = lines.groupBy { it.bookId }
             val result = mutableMapOf<Long, String>()
 

--- a/cli/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/cli/Main.kt
+++ b/cli/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/cli/Main.kt
@@ -7,6 +7,7 @@ import io.github.kdroidfilter.seforimlibrary.search.SearchEngine
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.databasesDir
 import io.github.vinceglb.filekit.path
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -229,25 +230,27 @@ fun runSearch(config: CliConfig) {
             val allResults = mutableListOf<SearchResultOutput>()
             var totalHits = 0L
 
-            do {
-                val page = s.nextPage(config.limit) ?: break
-                totalHits = page.totalHits
+            runBlocking {
+                do {
+                    val page = s.nextPage(config.limit) ?: break
+                    totalHits = page.totalHits
 
-                for (hit in page.hits) {
-                    allResults.add(
-                        SearchResultOutput(
-                            bookId = hit.bookId,
-                            bookTitle = hit.bookTitle,
-                            lineId = hit.lineId,
-                            lineIndex = hit.lineIndex,
-                            snippet = stripHtml(hit.snippet),
-                            score = hit.score,
+                    for (hit in page.hits) {
+                        allResults.add(
+                            SearchResultOutput(
+                                bookId = hit.bookId,
+                                bookTitle = hit.bookTitle,
+                                lineId = hit.lineId,
+                                lineIndex = hit.lineIndex,
+                                snippet = stripHtml(hit.snippet),
+                                score = hit.score,
+                            )
                         )
-                    )
-                }
+                    }
 
-                if (!config.fetchAll || page.isLastPage) break
-            } while (true)
+                    if (!config.fetchAll || page.isLastPage) break
+                } while (true)
+            }
 
             if (config.jsonOutput) {
                 val output = SearchOutput(

--- a/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/LuceneSearchEngine.kt
+++ b/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/LuceneSearchEngine.kt
@@ -1,6 +1,8 @@
 package io.github.kdroidfilter.seforimlibrary.search
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.apache.lucene.analysis.Analyzer
 import org.apache.lucene.analysis.TokenStream
 import org.apache.lucene.analysis.standard.StandardAnalyzer
@@ -330,20 +332,20 @@ class LuceneSearchEngine(
         private var finished = false
         private var totalHitsValue: Long? = null
 
-        override fun nextPage(limit: Int): SearchPage? {
-            if (finished) return null
+        override suspend fun nextPage(limit: Int): SearchPage? = withContext(Dispatchers.IO) {
+            if (finished) return@withContext null
             val top = searcher.searchAfter(after, query, limit)
             if (totalHitsValue == null) totalHitsValue = top.totalHits?.value
             if (top.scoreDocs.isEmpty()) {
                 finished = true
-                return null
+                return@withContext null
             }
             val stored = searcher.storedFields()
             val hits = mapScoreDocs(stored, top.scoreDocs.toList(), anchorTerms, highlightTerms)
             after = top.scoreDocs.last()
             val isLast = top.scoreDocs.size < limit
             if (isLast) finished = true
-            return SearchPage(
+            SearchPage(
                 hits = hits,
                 totalHits = totalHitsValue ?: hits.size.toLong(),
                 isLastPage = isLast
@@ -357,16 +359,16 @@ class LuceneSearchEngine(
 
     // --- Additional public search methods ---
 
-    fun searchAllText(rawQuery: String, near: Int = 5, limit: Int, offset: Int = 0): List<LineHit> =
+    suspend fun searchAllText(rawQuery: String, near: Int = 5, limit: Int, offset: Int = 0): List<LineHit> =
         doSearch(rawQuery, near, limit, offset, bookFilter = null, categoryFilter = null)
 
-    fun searchInBook(rawQuery: String, near: Int, bookId: Long, limit: Int, offset: Int = 0): List<LineHit> =
+    suspend fun searchInBook(rawQuery: String, near: Int, bookId: Long, limit: Int, offset: Int = 0): List<LineHit> =
         doSearch(rawQuery, near, limit, offset, bookFilter = bookId, categoryFilter = null)
 
-    fun searchInCategory(rawQuery: String, near: Int, categoryId: Long, limit: Int, offset: Int = 0): List<LineHit> =
+    suspend fun searchInCategory(rawQuery: String, near: Int, categoryId: Long, limit: Int, offset: Int = 0): List<LineHit> =
         doSearch(rawQuery, near, limit, offset, bookFilter = null, categoryFilter = categoryId)
 
-    fun searchInBooks(rawQuery: String, near: Int, bookIds: Collection<Long>, limit: Int, offset: Int = 0): List<LineHit> =
+    suspend fun searchInBooks(rawQuery: String, near: Int, bookIds: Collection<Long>, limit: Int, offset: Int = 0): List<LineHit> =
         doSearchInBooks(rawQuery, near, limit, offset, bookIds)
 
     // --- Private implementation ---
@@ -496,7 +498,9 @@ class LuceneSearchEngine(
         )
     }
 
-    private fun mapScoreDocs(
+    // suspend because it calls snippetProvider.getSnippetSources();
+    // callers are responsible for providing Dispatchers.IO context.
+    private suspend fun mapScoreDocs(
         stored: StoredFields,
         scoreDocs: List<ScoreDoc>,
         anchorTerms: List<String>,
@@ -568,7 +572,7 @@ class LuceneSearchEngine(
         return hits.sortedByDescending { it.score }
     }
 
-    private fun doSearch(
+    private suspend fun doSearch(
         rawQuery: String,
         near: Int,
         limit: Int,
@@ -577,15 +581,17 @@ class LuceneSearchEngine(
         categoryFilter: Long?
     ): List<LineHit> {
         val context = buildSearchContext(rawQuery, near, bookFilter, categoryFilter, null, null) ?: return emptyList()
-        return withSearcher { searcher ->
-            val top = searcher.search(context.query, offset + limit)
-            val stored: StoredFields = searcher.storedFields()
-            val sliced = top.scoreDocs.drop(offset)
-            mapScoreDocs(stored, sliced, context.anchorTerms, context.highlightTerms)
+        return withContext(Dispatchers.IO) {
+            withSearcher { searcher ->
+                val top = searcher.search(context.query, offset + limit)
+                val stored: StoredFields = searcher.storedFields()
+                val sliced = top.scoreDocs.drop(offset)
+                mapScoreDocs(stored, sliced, context.anchorTerms, context.highlightTerms)
+            }
         }
     }
 
-    private fun doSearchInBooks(
+    private suspend fun doSearchInBooks(
         rawQuery: String,
         near: Int,
         limit: Int,
@@ -594,11 +600,13 @@ class LuceneSearchEngine(
     ): List<LineHit> {
         if (bookIds.isEmpty()) return emptyList()
         val context = buildSearchContext(rawQuery, near, bookFilter = null, categoryFilter = null, bookIds = bookIds, lineIds = null) ?: return emptyList()
-        return withSearcher { searcher ->
-            val top = searcher.search(context.query, offset + limit)
-            val stored: StoredFields = searcher.storedFields()
-            val sliced = top.scoreDocs.drop(offset)
-            mapScoreDocs(stored, sliced, context.anchorTerms, context.highlightTerms)
+        return withContext(Dispatchers.IO) {
+            withSearcher { searcher ->
+                val top = searcher.search(context.query, offset + limit)
+                val stored: StoredFields = searcher.storedFields()
+                val sliced = top.scoreDocs.drop(offset)
+                mapScoreDocs(stored, sliced, context.anchorTerms, context.highlightTerms)
+            }
         }
     }
 

--- a/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/SearchSession.kt
+++ b/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/SearchSession.kt
@@ -36,7 +36,7 @@ interface SearchSession : Closeable {
      * @param limit Maximum number of results to return in this page
      * @return [SearchPage] containing hits and metadata, or null if no more results
      */
-    fun nextPage(limit: Int): SearchPage?
+    suspend fun nextPage(limit: Int): SearchPage?
 }
 
 /**

--- a/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/SnippetProvider.kt
+++ b/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/SnippetProvider.kt
@@ -50,5 +50,5 @@ fun interface SnippetProvider {
      * @param lines List of line metadata for which to fetch text
      * @return Map of lineId to its source text. Missing lines should be omitted.
      */
-    fun getSnippetSources(lines: List<LineSnippetInfo>): Map<Long, String>
+    suspend fun getSnippetSources(lines: List<LineSnippetInfo>): Map<Long, String>
 }

--- a/search/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/search/LuceneSearchEngineTest.kt
+++ b/search/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/search/LuceneSearchEngineTest.kt
@@ -1,5 +1,6 @@
 package io.github.kdroidfilter.seforimlibrary.search
 
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -152,7 +153,7 @@ class LuceneSearchEngineTest {
             val session = engine.openSession("שלום", 5)
             assertNotNull(session)
 
-            val page = session.nextPage(10)
+            val page = runBlocking { session.nextPage(10) }
             assertNotNull(page)
             assertTrue(page.hits.isNotEmpty())
             assertTrue(page.totalHits > 0)
@@ -175,27 +176,29 @@ class LuceneSearchEngineTest {
             val session = engine.openSession("טקסט", 5)
             assertNotNull(session)
 
-            // First page
-            val page1 = session.nextPage(10)
-            assertNotNull(page1)
-            assertEquals(10, page1.hits.size)
-            assertFalse(page1.isLastPage)
+            runBlocking {
+                // First page
+                val page1 = session.nextPage(10)
+                assertNotNull(page1)
+                assertEquals(10, page1.hits.size)
+                assertFalse(page1.isLastPage)
 
-            // Second page
-            val page2 = session.nextPage(10)
-            assertNotNull(page2)
-            assertEquals(10, page2.hits.size)
-            assertFalse(page2.isLastPage)
+                // Second page
+                val page2 = session.nextPage(10)
+                assertNotNull(page2)
+                assertEquals(10, page2.hits.size)
+                assertFalse(page2.isLastPage)
 
-            // Third page (last, should have 5 items)
-            val page3 = session.nextPage(10)
-            assertNotNull(page3)
-            assertEquals(5, page3.hits.size)
-            assertTrue(page3.isLastPage)
+                // Third page (last, should have 5 items)
+                val page3 = session.nextPage(10)
+                assertNotNull(page3)
+                assertEquals(5, page3.hits.size)
+                assertTrue(page3.isLastPage)
 
-            // No more pages
-            val page4 = session.nextPage(10)
-            assertNull(page4)
+                // No more pages
+                val page4 = session.nextPage(10)
+                assertNull(page4)
+            }
 
             session.close()
             engine.close()
@@ -294,7 +297,7 @@ class LuceneSearchEngineTest {
             val session = engine.openSession("טקסט", 5, bookFilter = 1L)
             assertNotNull(session)
 
-            val page = session.nextPage(100)
+            val page = runBlocking { session.nextPage(100) }
             assertNotNull(page)
 
             // All results should be from book 1
@@ -317,7 +320,7 @@ class LuceneSearchEngineTest {
             val session = engine.openSession("טקסט", 5, bookIds = listOf(1L, 2L))
             assertNotNull(session)
 
-            val page = session.nextPage(100)
+            val page = runBlocking { session.nextPage(100) }
             assertNotNull(page)
 
             // All results should be from books 1 or 2
@@ -342,7 +345,7 @@ class LuceneSearchEngineTest {
             val session = engine.openSession("שלום", 5)
             assertNotNull(session)
 
-            val page = session.nextPage(10)
+            val page = runBlocking { session.nextPage(10) }
             assertNotNull(page)
             assertTrue(page.hits.isNotEmpty())
 


### PR DESCRIPTION
## Summary
- Make `SnippetProvider.getSnippetSources` and `SearchSession.nextPage` suspend functions
- Propagate suspend through `LuceneSearchEngine` internals (`mapScoreDocs`, `doSearch`, `doSearchInBooks`, legacy public methods)
- Remove `runBlocking` from `CliSnippetProvider` and adapt CLI `Main.kt` with proper `runBlocking` at the call site
- Update tests to use `runBlocking` where needed

## Test plan
- [ ] `./gradlew :search:test` passes
- [ ] `./gradlew :cli:compileKotlinJvm` compiles
- [ ] Verify search results and snippets work correctly in the app

🔗 Related app-side PR will follow with `ResultsIndexingUseCase` and `RepositorySnippetSourceProvider` changes.