### PR TITLE
fix(sefaria): resolve 7 Sefaria import bugs from Zayit #392

### DIFF
--- a/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaAltTocBuilder.kt
+++ b/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaAltTocBuilder.kt
@@ -18,7 +18,13 @@ internal class SefariaAltTocBuilder(
 
         var hasGeneratedAltStructures = false
 
-        val isTalmudTractate = payload.categoriesHe.any { it.contains("תלמוד") }
+        // Only Bavli tractates should suppress alt-struct child enumeration —
+        // their main schema already renders daf-by-daf, so enumerating refs
+        // under the alt-struct produces duplicates. Yerushalmi uses a
+        // chapter×halakhah×segment main schema and Venice/Vilna alt-structs
+        // that MUST be expanded to produce daf (column) headings.
+        val isYerushalmi = payload.categoriesHe.any { it.contains("ירושלמי") }
+        val isTalmudTractate = payload.categoriesHe.any { it.contains("תלמוד") } && !isYerushalmi
         val isShulchanArukhCode = payload.categoriesHe.any { it.contains("שולחן ערוך") }
         val isTurCode = payload.categoriesHe.any { it.contains("טור") }
 
@@ -224,22 +230,7 @@ internal class SefariaAltTocBuilder(
                 return null to null
             }
 
-            fun mapBaseToHebrew(base: String?): String? {
-                if (base.isNullOrBlank()) return null
-                val norm = base.lowercase()
-                return when {
-                    "aliyah" in norm -> "עליה"
-                    "daf" in norm -> "דף"
-                    "chapter" in norm -> "פרק"
-                    "perek" in norm -> "פרק"
-                    "siman" in norm -> "סימן"
-                    "section" in norm -> "סימן"
-                    "klal" in norm -> "כלל"
-                    "psalm" in norm || "psalms" in norm -> "מזמור"
-                    "day" in norm -> "יום"
-                    else -> base
-                }
-            }
+            fun mapBaseToHebrew(base: String?): String? = mapSectionNameToHebrew(base)
 
             fun buildChildLabel(base: String?, idx: Int, addressValue: Int?, addressType: String?): String {
                 val numericValue = (addressValue ?: (idx + 1)).coerceAtLeast(1)

--- a/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaBookPayloadReader.kt
+++ b/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaBookPayloadReader.kt
@@ -293,10 +293,11 @@ internal class SefariaBookPayloadReader(
                     processNode(childNode, childText, level + 1, nextRefPrefix, nextHeRefPrefix)
                 }
             } else {
-                val sectionNames = node["heSectionNames"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+                val sectionNames = readHeSectionNames(node)
                 val depth = node["depth"]?.jsonPrimitive?.intOrNullSafe() ?: sectionNames.size
                 val addressTypes = node["addressTypes"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
                 val referenceableSections = node["referenceableSections"]?.jsonArray?.mapNotNull { it.jsonPrimitive.booleanOrNull } ?: emptyList()
+                val childRefOffsets = readIndexOffsets(node, depth)
                 val nextLevel = if (hasTitle) level + 1 else level
                 recursiveSections(
                     sectionNames = sectionNames,
@@ -311,7 +312,8 @@ internal class SefariaBookPayloadReader(
                     bookHeTitle = bookHeTitle,
                     headings = headings,
                     addressTypes = addressTypes,
-                    referenceableSections = referenceableSections
+                    referenceableSections = referenceableSections,
+                    childRefOffsets = childRefOffsets
                 )
             }
         }
@@ -337,10 +339,11 @@ internal class SefariaBookPayloadReader(
                 processNode(node, nodeText, 1, refPrefix, heRefPrefix)
             }
         } else {
-            val sectionNames = schemaObj["heSectionNames"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+            val sectionNames = readHeSectionNames(schemaObj)
             val depth = schemaObj["depth"]?.jsonPrimitive?.intOrNullSafe() ?: sectionNames.size
             val addressTypes = schemaObj["addressTypes"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
             val referenceableSections = schemaObj["referenceableSections"]?.jsonArray?.mapNotNull { it.jsonPrimitive.booleanOrNull } ?: emptyList()
+            val childRefOffsets = readIndexOffsets(schemaObj, depth)
             recursiveSections(
                 sectionNames = sectionNames,
                 text = textElement,
@@ -354,7 +357,8 @@ internal class SefariaBookPayloadReader(
                 bookHeTitle = bookHeTitle,
                 headings = headings,
                 addressTypes = addressTypes,
-                referenceableSections = referenceableSections
+                referenceableSections = referenceableSections,
+                childRefOffsets = childRefOffsets
             )
         }
 
@@ -375,23 +379,39 @@ internal class SefariaBookPayloadReader(
         headings: MutableList<Heading>,
         linePrefix: String = "",
         addressTypes: List<String> = emptyList(),
-        referenceableSections: List<Boolean> = emptyList()
+        referenceableSections: List<Boolean> = emptyList(),
+        // Offsets applied to the *English* ref number built at this iteration.
+        // Propagated from `index_offsets_by_depth` so Zohar-style books emit
+        // the same global paragraph indices that Sefaria links use (e.g.
+        // "Zohar, Tetzaveh 14:127" instead of "14:13"). See readIndexOffsets.
+        refIndexOffset: Int = 0,
+        // Offsets to hand down to the *children* of the iteration at this
+        // level (one entry per outer-dim index).
+        childRefOffsets: List<Int>? = null
     ) {
-        if (depth == 0) {
-            val primitive = text as? JsonPrimitive
-            val content = primitive?.takeIf { it.isString }?.content
+        // Leaf when depth reached zero, OR when the data is shallower than the
+        // schema declares (e.g. Keter Malkhut: schema says depth=2 but most
+        // chapters are stored as a single string instead of a paragraph array).
+        // Falling through to `text !is JsonArray return` would silently drop
+        // the chapter's content.
+        val leafPrimitive = text as? JsonPrimitive
+        if (depth == 0 || (leafPrimitive != null && leafPrimitive.isString)) {
+            val content = leafPrimitive?.takeIf { it.isString }?.content
             if (!content.isNullOrEmpty()) {
-                output += linePrefix + content.replace("\n", "")
-                val cleanRef = trimTrailingSeparators(refPrefix)
-                val cleanHeRef = trimTrailingSeparators(heRefPrefix)
-                refEntries.add(
-                    RefEntry(
-                        ref = cleanRef,
-                        heRef = cleanHeRef,
-                        path = "",
-                        lineIndex = output.size
+                val cleaned = cleanSefariaLine(content)
+                if (cleaned.isNotEmpty()) {
+                    output += linePrefix + cleaned
+                    val cleanRef = trimTrailingSeparators(refPrefix)
+                    val cleanHeRef = trimTrailingSeparators(heRefPrefix)
+                    refEntries.add(
+                        RefEntry(
+                            ref = cleanRef,
+                            heRef = cleanHeRef,
+                            path = "",
+                            lineIndex = output.size
+                        )
                     )
-                )
+                }
             }
             return
         }
@@ -438,11 +458,15 @@ internal class SefariaBookPayloadReader(
                 )
             }
 
+            // Paragraph/ref offset from index_offsets_by_depth (Zohar-style):
+            // for the current iteration's element i, children should build refs
+            // as "(i+1):(offset[i]+childIdx+1)".
+            val shiftedIdx = idx + 1 + refIndexOffset
             val newRefPrefix = buildString {
                 append(refPrefix)
                 val refNumber = when (currentAddressType) {
-                    "Talmud" -> toEnglishDaf(idx + 1)
-                    else -> (idx + 1).toString()
+                    "Talmud" -> toEnglishDaf(shiftedIdx)
+                    else -> shiftedIdx.toString()
                 }
                 append(refNumber)
                 append(":")
@@ -452,6 +476,7 @@ internal class SefariaBookPayloadReader(
                 append(letter)
                 append(", ")
             }
+            val nextRefIndexOffset = childRefOffsets?.getOrNull(idx) ?: 0
 
             recursiveSections(
                 sectionNames = sectionNames,
@@ -467,8 +492,57 @@ internal class SefariaBookPayloadReader(
                 headings = headings,
                 linePrefix = nextLinePrefix,
                 addressTypes = addressTypes,
-                referenceableSections = referenceableSections
+                referenceableSections = referenceableSections,
+                refIndexOffset = nextRefIndexOffset
             )
+        }
+    }
+
+    /**
+     * Reads `index_offsets_by_depth` from a schema node and returns the list
+     * of cumulative offsets that should be applied to the child iteration
+     * when building English refs.
+     *
+     * Sefaria uses this mechanism for books like Zohar where chapters are
+     * stored as arrays but references use a single global paragraph index
+     * per parasha (e.g. "Zohar, Tetzaveh 14:127" means the 127th paragraph of
+     * Tetzaveh, which happens to live inside chapter 14). Without these
+     * offsets the alt-struct daf refs (and all external Zohar links) fail to
+     * resolve and pages like קפו: end up missing from the daf navigation.
+     *
+     * The map is keyed by the schema `depth` it applies at; the only
+     * practical use so far is `{"2": [...]}` on depth-2 Zohar-style nodes.
+     */
+    private fun readIndexOffsets(node: JsonObject, schemaDepth: Int): List<Int>? {
+        val map = node["index_offsets_by_depth"]?.jsonObject ?: return null
+        val key = schemaDepth.toString()
+        val arr = map[key]?.jsonArray ?: return null
+        val offsets = arr.mapNotNull { it.jsonPrimitive.intOrNullSafe() }
+        return if (offsets.isNotEmpty()) offsets else null
+    }
+
+    /**
+     * Returns the Hebrew section names for a schema node, filling in blanks
+     * with a best-effort mapping from the English `sectionNames` counterpart.
+     *
+     * Sefaria schemas frequently ship `heSectionNames=["", "פסקה"]` where the
+     * top-level Hebrew label (e.g. "תשובה", "סימן") was never filled in; the
+     * English `sectionNames` still has it. Without this fallback the importer
+     * skips the matching heading and responsa-style books end up with no TOC.
+     */
+    private fun readHeSectionNames(obj: JsonObject): List<String> {
+        val he = obj["heSectionNames"]?.jsonArray?.map { it.jsonPrimitive.contentOrNull.orEmpty() } ?: emptyList()
+        val en = obj["sectionNames"]?.jsonArray?.map { it.jsonPrimitive.contentOrNull.orEmpty() } ?: emptyList()
+        val size = maxOf(he.size, en.size)
+        if (size == 0) return emptyList()
+        return List(size) { idx ->
+            val heVal = he.getOrNull(idx)?.trim().orEmpty()
+            if (heVal.isNotEmpty()) {
+                heVal
+            } else {
+                val enVal = en.getOrNull(idx)?.trim().orEmpty()
+                mapSectionNameToHebrew(enVal.ifBlank { null }).orEmpty()
+            }
         }
     }
 

--- a/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaDirectImporter.kt
+++ b/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaDirectImporter.kt
@@ -40,6 +40,19 @@ class SefariaDirectImporter(
         val bookPayloadReader = SefariaBookPayloadReader(json, logger)
         val schemaLookup = bookPayloadReader.buildSchemaLookup(schemaDir)
 
+        // Pre-download every `textimages.sefaria.org` asset and cache as base64
+        // so that merged.json content can be inlined as `data:image/...` URIs.
+        // Without this, books like Tikkunei Zohar render broken ❌ placeholders
+        // (issue 392). This scan reads all merged.json once; the embedder uses
+        // a disk cache under build/sefaria/image-cache so re-runs skip network.
+        val mergedFiles = java.nio.file.Files.walk(jsonDir).use { stream ->
+            stream.filter {
+                java.nio.file.Files.isRegularFile(it) &&
+                    it.fileName.toString().equals("merged.json", ignoreCase = true)
+            }.toList()
+        }
+        SefariaImageEmbedder.prefetch(mergedFiles, logger = logger)
+
         // Read and parse files in parallel
         logger.i { "Starting parallel file processing..." }
         val bookPayloads = bookPayloadReader.readBooksInParallel(jsonDir, schemaDir, schemaLookup)

--- a/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaImageEmbedder.kt
+++ b/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaImageEmbedder.kt
@@ -1,0 +1,238 @@
+package io.github.kdroidfilter.seforimlibrary.sefariasqlite
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.time.Duration
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readBytes
+
+/**
+ * Downloads `textimages.sefaria.org` images referenced from book content and
+ * keeps an in-memory + on-disk cache of the corresponding `data:image/(mime);base64,...`
+ * URIs.
+ *
+ * Once populated, [cleanSefariaLine] can use [substituteImages] to inline the
+ * base64 payloads so the resulting SQLite DB is self-contained (no runtime
+ * network dependency on textimages.sefaria.org, whose images render as broken
+ * ❌ placeholders in offline use — see issue 392).
+ *
+ * Workflow:
+ *   1. [prefetch] — scan all merged.json paths once, collect unique image URLs,
+ *      download anything not yet cached, populate the in-memory map.
+ *   2. [substituteImages] — pure function, rewrites `<img src="…">` occurrences
+ *      to `<img src="data:…">`; called from [cleanSefariaLine].
+ */
+object SefariaImageEmbedder {
+    private const val URL_PREFIX = "https://textimages.sefaria.org/"
+    private const val USER_AGENT = "SeforimLibrary-SefariaImageEmbedder/1.0"
+    private const val DOWNLOAD_PARALLELISM = 16
+    private const val MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5 MiB ceiling per image
+
+    private val client: HttpClient by lazy {
+        HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(20))
+            .build()
+    }
+
+    // Regex used both to detect URLs up-front and to rewrite them inline.
+    // Captures: (1) the full URL, (2) nothing — we replace the URL inside the
+    // matched `<img ...>` tag so surrounding attributes are preserved.
+    private val IMG_TAG_REGEX = Regex(
+        "<img\\s+[^>]*src=[\"'](https://textimages\\.sefaria\\.org/[^\"']+)[\"'][^>]*/?>",
+        RegexOption.IGNORE_CASE
+    )
+
+    private val dataUriByUrl = ConcurrentHashMap<String, String>()
+
+    /**
+     * Set by the importer at startup. When null, [substituteImages] is a no-op
+     * and the original URLs are kept (so tests/debug runs don't require network).
+     */
+    @Volatile
+    var enabled: Boolean = false
+        private set
+
+    /**
+     * Scan [mergedJsonPaths], extract unique Sefaria image URLs, download any
+     * that aren't already in [cacheDir], and populate the in-memory data-URI map.
+     * Safe to call multiple times — already-cached entries are reused.
+     */
+    suspend fun prefetch(
+        mergedJsonPaths: Collection<Path>,
+        cacheDir: Path = Paths.get("build", "sefaria", "image-cache"),
+        logger: Logger = Logger.withTag("SefariaImageEmbedder")
+    ) = coroutineScope {
+        Files.createDirectories(cacheDir)
+
+        val urls = collectUrls(mergedJsonPaths)
+        if (urls.isEmpty()) {
+            enabled = true
+            return@coroutineScope
+        }
+        logger.i { "Embedder: ${urls.size} unique Sefaria image URLs to process" }
+
+        val semaphore = Semaphore(DOWNLOAD_PARALLELISM)
+        var newlyDownloaded = 0
+        var failed = 0
+
+        urls.map { url ->
+            async(Dispatchers.IO) {
+                semaphore.withPermit {
+                    val cached = ensureCachedBytes(url, cacheDir, logger)
+                    if (cached != null) {
+                        if (cached.fromNetwork) newlyDownloaded++
+                        dataUriByUrl[url] = toDataUri(url, cached.bytes)
+                    } else {
+                        failed++
+                    }
+                }
+            }
+        }.awaitAll()
+
+        enabled = true
+        logger.i {
+            "Embedder: cached=${dataUriByUrl.size} (downloaded=$newlyDownloaded, failed=$failed)"
+        }
+    }
+
+    /**
+     * Substitute every `<img src="https://textimages.sefaria.org/…">` with a
+     * matching `data:` URI, assuming [prefetch] populated the cache.
+     * Preserves any other attributes on the tag.
+     */
+    fun substituteImages(content: String): String {
+        if (!enabled || !content.contains(URL_PREFIX)) return content
+        return IMG_TAG_REGEX.replace(content) { match ->
+            val url = match.groupValues[1]
+            val dataUri = dataUriByUrl[url] ?: return@replace match.value
+            match.value.replace(url, dataUri)
+        }
+    }
+
+    /**
+     * Drop all in-memory cache state (does not touch disk cache). Mostly for tests.
+     */
+    internal fun resetForTest() {
+        dataUriByUrl.clear()
+        enabled = false
+    }
+
+    /**
+     * Seed the in-memory cache directly (tests only — lets us skip the network).
+     */
+    internal fun seedForTest(url: String, dataUri: String) {
+        dataUriByUrl[url] = dataUri
+        enabled = true
+    }
+
+    private fun collectUrls(mergedJsonPaths: Collection<Path>): Set<String> {
+        val out = HashSet<String>()
+        val bytePattern = URL_PREFIX.toByteArray(Charsets.UTF_8)
+        val textRegex = Regex("https://textimages\\.sefaria\\.org/[^\"'<>\\s\\\\]+")
+        for (p in mergedJsonPaths) {
+            val bytes = runCatching { Files.readAllBytes(p) }.getOrNull() ?: continue
+            if (indexOfSubSequence(bytes, bytePattern) < 0) continue
+            val text = bytes.toString(Charsets.UTF_8)
+            for (m in textRegex.findAll(text)) {
+                out += stripTrailingJsonArtifacts(m.value)
+            }
+        }
+        return out
+    }
+
+    private fun stripTrailingJsonArtifacts(url: String): String {
+        // Sefaria JSON sometimes embeds URLs ending with a stray backslash or
+        // punctuation from the surrounding content. Keep only characters that
+        // are legal in a URL path.
+        return url.trimEnd('\\', '\'', '"', ',', '.', ';', ')', ']', '}')
+    }
+
+    private fun indexOfSubSequence(haystack: ByteArray, needle: ByteArray): Int {
+        if (needle.isEmpty() || haystack.size < needle.size) return -1
+        outer@ for (i in 0..(haystack.size - needle.size)) {
+            for (j in needle.indices) {
+                if (haystack[i + j] != needle[j]) continue@outer
+            }
+            return i
+        }
+        return -1
+    }
+
+    private data class CachedBytes(val bytes: ByteArray, val fromNetwork: Boolean)
+
+    private fun ensureCachedBytes(url: String, cacheDir: Path, logger: Logger): CachedBytes? {
+        val cachePath = cacheDir.resolve(cacheFileName(url))
+        if (cachePath.exists() && cachePath.isRegularFile()) {
+            return runCatching { CachedBytes(cachePath.readBytes(), fromNetwork = false) }
+                .getOrElse {
+                    logger.w(it) { "Corrupted cached image at $cachePath; redownloading" }
+                    runCatching { Files.delete(cachePath) }
+                    null
+                }
+                ?: return ensureCachedBytes(url, cacheDir, logger)
+        }
+
+        val bytes = runCatching { downloadBytes(url) }.getOrElse {
+            logger.w(it) { "Failed to download image: $url" }
+            return null
+        }
+        if (bytes.size > MAX_IMAGE_BYTES) {
+            logger.w { "Skipping oversized image (${bytes.size} bytes): $url" }
+            return null
+        }
+        val tmp = cachePath.resolveSibling(cachePath.fileName.toString() + ".part")
+        Files.createDirectories(cachePath.parent)
+        Files.write(tmp, bytes)
+        Files.move(tmp, cachePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+        return CachedBytes(bytes, fromNetwork = true)
+    }
+
+    private fun downloadBytes(url: String): ByteArray {
+        val request = HttpRequest.newBuilder(URI.create(url))
+            .timeout(Duration.ofSeconds(30))
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "image/*")
+            .build()
+        val response = client.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        if (response.statusCode() !in 200..299) {
+            throw IllegalStateException("HTTP ${response.statusCode()} for $url")
+        }
+        return response.body()
+    }
+
+    private fun cacheFileName(url: String): String {
+        val keyPart = url.removePrefix(URL_PREFIX)
+        return keyPart.replace('/', '_').replace(':', '_').replace('?', '_')
+    }
+
+    private fun toDataUri(url: String, bytes: ByteArray): String {
+        val mime = when {
+            url.endsWith(".png", ignoreCase = true) -> "image/png"
+            url.endsWith(".jpg", ignoreCase = true) || url.endsWith(".jpeg", ignoreCase = true) -> "image/jpeg"
+            url.endsWith(".gif", ignoreCase = true) -> "image/gif"
+            url.endsWith(".svg", ignoreCase = true) -> "image/svg+xml"
+            url.endsWith(".webp", ignoreCase = true) -> "image/webp"
+            else -> "image/png"
+        }
+        val b64 = Base64.getEncoder().encodeToString(bytes)
+        return "data:$mime;base64,$b64"
+    }
+}

--- a/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaImportText.kt
+++ b/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaImportText.kt
@@ -5,6 +5,74 @@ internal fun sanitizeFolder(name: String?): String {
     return name.replace("\"", "״").trim()
 }
 
+// Legacy Otzar HaChochma style/format markers that Sefaria did not strip when
+// ingesting some books (e.g. Maaseh Rokeach, Malbim). Pattern is `@NN<text>}`
+// where NN is a two-digit style code. We keep the inner text, drop the marker.
+private val OTZAR_MARKUP_REGEX = Regex("""@\d{2}([^}]*)\}""")
+
+// Sefaria's merged.json for some books (most notably Tikkunei Zohar from daf
+// יז onward) uses `<br>` tags to mark internal line breaks inside what is
+// logically a single paragraph — typically piyut/poetry sections. The app
+// renders each `<br>`-delimited fragment as its own short line, which
+// regresses the legacy plain-text Otzaria experience where the paragraph was
+// continuous. Collapse them to a single space so paragraphs read as prose.
+private val HTML_LINE_BREAK_REGEX = Regex("""<br\s*/?>""", RegexOption.IGNORE_CASE)
+
+internal fun cleanSefariaLine(raw: String): String {
+    var s = if (raw.contains('\n')) raw.replace("\n", "") else raw
+    if (OTZAR_MARKUP_REGEX.containsMatchIn(s)) {
+        s = OTZAR_MARKUP_REGEX.replace(s, "$1")
+    }
+    if (HTML_LINE_BREAK_REGEX.containsMatchIn(s)) {
+        s = HTML_LINE_BREAK_REGEX.replace(s, " ")
+        // Collapse any double spaces we just introduced
+        s = s.replace(Regex(" {2,}"), " ").trim()
+    }
+    // Inline any Sefaria textimages as base64 data URIs (no-op if the embedder
+    // hasn't been prefetched or the line contains no such URL).
+    s = SefariaImageEmbedder.substituteImages(s)
+    return s
+}
+
+/**
+ * Maps common Sefaria English section/address names to their Hebrew equivalents.
+ * Used when a schema only exposes `sectionNames` (English) without the
+ * matching `heSectionNames`, so the generated TOC labels fall back gracefully
+ * instead of showing English strings mid-Hebrew UI.
+ *
+ * Returns the original string if no mapping applies, or `null` for blank input.
+ */
+internal fun mapSectionNameToHebrew(base: String?): String? {
+    if (base.isNullOrBlank()) return null
+    val norm = base.lowercase()
+    return when {
+        "aliyah" in norm || "aliya" in norm -> "עליה"
+        "daf" in norm -> "דף"
+        "chapter" in norm -> "פרק"
+        "perek" in norm -> "פרק"
+        "siman" in norm -> "סימן"
+        "seif" in norm -> "סעיף"
+        "section" in norm -> "סימן"
+        "klal" in norm -> "כלל"
+        "psalm" in norm -> "מזמור"
+        "day" in norm -> "יום"
+        "tikkun" in norm -> "תיקון"
+        "parasha" in norm || "parsha" in norm -> "פרשה"
+        "mishna" in norm -> "משנה"
+        "halakha" in norm || "halacha" in norm -> "הלכה"
+        "volume" in norm -> "כרך"
+        "part" in norm -> "חלק"
+        "verse" in norm || "pasuk" in norm -> "פסוק"
+        "teshuva" in norm || "responsum" in norm || "responsa" in norm -> "תשובה"
+        "paragraph" in norm -> "פסקה"
+        "line" in norm -> "שורה"
+        "column" in norm -> "טור"
+        "folio" in norm -> "דף"
+        "segment" in norm -> "קטע"
+        else -> base
+    }
+}
+
 internal fun normalizeTitleKey(value: String?): String? {
     if (value.isNullOrBlank()) return null
 

--- a/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaCleanSefariaLineTest.kt
+++ b/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaCleanSefariaLineTest.kt
@@ -1,0 +1,61 @@
+package io.github.kdroidfilter.seforimlibrary.sefariasqlite
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SefariaCleanSefariaLineTest {
+    @Test
+    fun stripsOtzarMarkupAtLineStart() {
+        // Real example from Maaseh Rokeach on Vessels (chapter 5, halacha 3)
+        assertEquals("והנקטמון", cleanSefariaLine("@04והנקטמון}"))
+    }
+
+    @Test
+    fun stripsOtzarMarkupInline() {
+        assertEquals(
+            "לא ידעתי לפרש דברי רבינו וכן",
+            cleanSefariaLine("לא ידעתי לפרש דברי רבינו @04וכן}")
+        )
+    }
+
+    @Test
+    fun preservesCurlyBraceWhenNotFromMarker() {
+        // Sefaria texts sometimes contain legitimate braces (parentheses in old formats).
+        // Only the @NN...} pattern should be stripped.
+        assertEquals("{word} text", cleanSefariaLine("{word} text"))
+    }
+
+    @Test
+    fun stripsMultipleMarkers() {
+        assertEquals(
+            "one and two",
+            cleanSefariaLine("@04one} and @44two}")
+        )
+    }
+
+    @Test
+    fun stripsNewlinesAsBefore() {
+        assertEquals("a b", cleanSefariaLine("a\nb".replace("b", " b")))
+    }
+
+    @Test
+    fun passThroughWhenNoMarkup() {
+        assertEquals("בראשית ברא אלהים", cleanSefariaLine("בראשית ברא אלהים"))
+    }
+
+    @Test
+    fun collapsesBrTagsIntoSpaces() {
+        // Sample from Tikkunei Zohar daf יז (idx=33 in merged.json): the
+        // paragraph is internally split by <br> tags, which the app used to
+        // render as short broken lines.
+        assertEquals(
+            "ובר מינך לית יחודא בעלאי ותתאי. ואנת אשתמודע אדון על כלא.",
+            cleanSefariaLine("ובר מינך לית יחודא <br>בעלאי ותתאי. <br>ואנת אשתמודע אדון על כלא.")
+        )
+    }
+
+    @Test
+    fun handlesSelfClosingAndUppercaseBr() {
+        assertEquals("a b c", cleanSefariaLine("a<br/>b<BR />c"))
+    }
+}

--- a/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaImageEmbedderTest.kt
+++ b/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaImageEmbedderTest.kt
@@ -1,0 +1,64 @@
+package io.github.kdroidfilter.seforimlibrary.sefariasqlite
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit test for the in-memory replacement path of [SefariaImageEmbedder].
+ * Network downloading + disk caching is covered end-to-end by the full
+ * importer run (see SefariaDirectImporter.import).
+ */
+class SefariaImageEmbedderTest {
+    @BeforeTest fun reset() = SefariaImageEmbedder.resetForTest()
+    @AfterTest fun clean() = SefariaImageEmbedder.resetForTest()
+
+    @Test
+    fun substituteImagesReplacesKnownUrlsInImgTags() {
+        val url = "https://textimages.sefaria.org/Tikkunei_Zohar/40.png"
+        val dataUri = "data:image/png;base64,AAAA"
+        SefariaImageEmbedder.seedForTest(url, dataUri)
+
+        val input = """prefix <img src="$url"> middle <img src="$url" class="x"> end"""
+        val out = cleanSefariaLine(input)
+
+        assertTrue(out.contains("data:image/png;base64,AAAA"))
+        assertFalse(out.contains(url), "original URL should be replaced")
+    }
+
+    @Test
+    fun unknownUrlIsPreservedVerbatim() {
+        // Embedder enabled but URL not in cache — leave it alone so it's
+        // obvious (and fixable) instead of silently dropping content.
+        SefariaImageEmbedder.seedForTest(
+            "https://textimages.sefaria.org/known.png",
+            "data:image/png;base64,Z"
+        )
+        val input = """<img src="https://textimages.sefaria.org/unknown.png">"""
+        assertEquals(input, cleanSefariaLine(input))
+    }
+
+    @Test
+    fun noOpWhenEmbedderDisabled() {
+        // Without prefetch, substituteImages is a pass-through
+        val input = """<img src="https://textimages.sefaria.org/x.png">"""
+        assertEquals(input, cleanSefariaLine(input))
+    }
+
+    @Test
+    fun compatibleWithOtherCleanSteps() {
+        SefariaImageEmbedder.seedForTest(
+            "https://textimages.sefaria.org/a.png",
+            "data:image/png;base64,X"
+        )
+        // Otzar markup, <br>, and image embedding all in one line
+        val input = """@04פתיחה} <br> <img src="https://textimages.sefaria.org/a.png"> text"""
+        val out = cleanSefariaLine(input)
+        assertTrue(out.startsWith("פתיחה"))
+        assertFalse(out.contains("<br>"))
+        assertTrue(out.contains("data:image/png;base64,X"))
+    }
+}

--- a/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaKeterMalkhutTest.kt
+++ b/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaKeterMalkhutTest.kt
@@ -1,0 +1,137 @@
+package io.github.kdroidfilter.seforimlibrary.sefariasqlite
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression for https://github.com/kdroidFilter/Zayit/issues/392 (Keter Malkhut):
+ * the book's schema declares `depth=2` (Chapter × Paragraph) but the merged
+ * `text` is effectively 1-D — most chapters are a single string rather than a
+ * paragraph array. Before the fix, the importer hit the `text !is JsonArray`
+ * guard at depth=1 and silently dropped every stanza, leaving only the
+ * `<h2>פרק N</h2>` headings.
+ */
+class SefariaKeterMalkhutTest {
+    @Test
+    fun chapterStanzaStoredAsStringStillBecomesContentLine() = runBlocking {
+        val tempDir = Files.createTempDirectory("seforim-keter")
+        val schemaDir = Files.createDirectories(tempDir.resolve("schemas"))
+        val jsonDir = Files.createDirectories(tempDir.resolve("json"))
+        val bookDir = Files.createDirectories(jsonDir.resolve("Keter Malkhut"))
+
+        Files.writeString(schemaDir.resolve("Keter_Malkhut.json"), schemaJson)
+        Files.writeString(bookDir.resolve("merged.json"), mergedJson)
+
+        val reader = SefariaBookPayloadReader(
+            Json { ignoreUnknownKeys = true; coerceInputValues = true },
+            Logger.withTag("SefariaKeterMalkhutTest")
+        )
+        val schemaLookup = reader.buildSchemaLookup(schemaDir)
+        val payload = reader.readBooksInParallel(jsonDir, schemaDir, schemaLookup).single()
+
+        val perekA = payload.headings.firstOrNull { it.title == "פרק א" }
+        val perekB = payload.headings.firstOrNull { it.title == "פרק ב" }
+        assertTrue(perekA != null, "expected <h2>פרק א</h2> heading")
+        assertTrue(perekB != null, "expected <h2>פרק ב</h2> heading")
+
+        // Stanza content must survive the schema-vs-data mismatch
+        assertTrue(
+            payload.lines.any { it.contains("נִפְלָאִים") },
+            "stanza from chapter 2 should be present as a content line"
+        )
+        assertTrue(
+            payload.lines.any { it.contains("בִּתְפִלָּתִי") },
+            "stanza from chapter 1 should be present as a content line"
+        )
+
+        // Chapter 1 stanza is referenced as 'כתר מלכות א'
+        val refA = payload.refEntries.firstOrNull { it.heRef == "כתר מלכות א" }
+        assertTrue(refA != null, "chapter 1 should have heRef 'כתר מלכות א'")
+    }
+
+    @Test
+    fun legitimate2dChapterStillExpandsToParagraphs() = runBlocking {
+        // Guard that the primitive-fallback doesn't short-circuit books where
+        // the data actually matches the schema.
+        val tempDir = Files.createTempDirectory("seforim-2d")
+        val schemaDir = Files.createDirectories(tempDir.resolve("schemas"))
+        val jsonDir = Files.createDirectories(tempDir.resolve("json"))
+        val bookDir = Files.createDirectories(jsonDir.resolve("FakeBook"))
+
+        Files.writeString(schemaDir.resolve("FakeBook.json"), schema2dJson)
+        Files.writeString(bookDir.resolve("merged.json"), merged2dJson)
+
+        val reader = SefariaBookPayloadReader(
+            Json { ignoreUnknownKeys = true; coerceInputValues = true },
+            Logger.withTag("SefariaKeterMalkhutTest")
+        )
+        val schemaLookup = reader.buildSchemaLookup(schemaDir)
+        val payload = reader.readBooksInParallel(jsonDir, schemaDir, schemaLookup).single()
+
+        // 2 chapters × 2 paragraphs → 4 paragraph refs
+        assertEquals(4, payload.refEntries.size)
+    }
+
+    companion object {
+        private val schemaJson = """
+            {
+              "title": "Keter Malkhut",
+              "heTitle": "כתר מלכות",
+              "schema": {
+                "nodeType": "JaggedArrayNode",
+                "depth": 2,
+                "addressTypes": ["Perek", "Integer"],
+                "sectionNames": ["Chapter", "Paragraph"],
+                "heSectionNames": ["פרק", "פסקה"],
+                "title": "Keter Malkhut",
+                "heTitle": "כתר מלכות"
+              }
+            }
+        """.trimIndent()
+
+        // Real shape: outer array is chapters, most are a primitive string
+        private val mergedJson = """
+            {
+              "title": "Keter Malkhut",
+              "heTitle": "כתר מלכות",
+              "text": [
+                "בִּתְפִלָּתִי יִסְכָּן גָּבֶר",
+                "נִפְלָאִים מַעֲשֶׂיךָ",
+                "אַתָּה אֶחָד"
+              ]
+            }
+        """.trimIndent()
+
+        private val schema2dJson = """
+            {
+              "title": "FakeBook",
+              "heTitle": "ספר",
+              "schema": {
+                "nodeType": "JaggedArrayNode",
+                "depth": 2,
+                "addressTypes": ["Perek", "Integer"],
+                "sectionNames": ["Chapter", "Verse"],
+                "heSectionNames": ["פרק", "פסוק"],
+                "title": "FakeBook",
+                "heTitle": "ספר"
+              }
+            }
+        """.trimIndent()
+
+        private val merged2dJson = """
+            {
+              "title": "FakeBook",
+              "heTitle": "ספר",
+              "text": [
+                ["ch1 p1", "ch1 p2"],
+                ["ch2 p1", "ch2 p2"]
+              ]
+            }
+        """.trimIndent()
+    }
+}

--- a/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaResponsaTocTest.kt
+++ b/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaResponsaTocTest.kt
@@ -1,0 +1,84 @@
+package io.github.kdroidfilter.seforimlibrary.sefariasqlite
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression for https://github.com/kdroidFilter/Zayit/issues/392 (responsa TOC):
+ *
+ * Sefaria schemas for Chavot Yair, Teshuvot HaRi Migash, Ohr HaSekhel,
+ * Shut Chatam Sofer, Noda BiYehuda, Shut HaRashba etc. ship
+ * `heSectionNames=["", "פסקה"]` — the top-level Hebrew label ("תשובה",
+ * "סימן", "חלק"...) is left empty even though `sectionNames=["Teshuva", ...]`
+ * is populated. The old importer read `heSectionNames` strictly, so it
+ * emitted blank `<h2></h2>` and generated no TOC at all.
+ */
+class SefariaResponsaTocTest {
+    @Test
+    fun blankHeSectionNameFallsBackToEnglishTranslation() = runBlocking {
+        val tempDir = Files.createTempDirectory("seforim-responsa")
+        val schemaDir = Files.createDirectories(tempDir.resolve("schemas"))
+        val jsonDir = Files.createDirectories(tempDir.resolve("json"))
+        val bookDir = Files.createDirectories(jsonDir.resolve("Havot Yair"))
+
+        Files.writeString(schemaDir.resolve("Havot_Yair.json"), schemaJson)
+        Files.writeString(bookDir.resolve("merged.json"), mergedJson)
+
+        val reader = SefariaBookPayloadReader(
+            Json { ignoreUnknownKeys = true; coerceInputValues = true },
+            Logger.withTag("SefariaResponsaTocTest")
+        )
+        val schemaLookup = reader.buildSchemaLookup(schemaDir)
+        val payload = reader.readBooksInParallel(jsonDir, schemaDir, schemaLookup).single()
+
+        // Sanity: content is present
+        assertTrue(payload.lines.any { it.contains("text of teshuva 1") })
+
+        // Before the fix, there was no heading for "Teshuva N" because heSectionNames[0] == "".
+        val teshuvaA = payload.headings.firstOrNull { it.title == "תשובה א" }
+        val teshuvaB = payload.headings.firstOrNull { it.title == "תשובה ב" }
+        assertTrue(teshuvaA != null, "expected <h2>תשובה א</h2> heading (got ${payload.headings.map { it.title }})")
+        assertTrue(teshuvaB != null, "expected <h2>תשובה ב</h2> heading (got ${payload.headings.map { it.title }})")
+
+        // heRef for the first paragraph of the first teshuva should use the Hebrew label chain
+        assertTrue(
+            payload.refEntries.any { it.heRef == "חוות יאיר א, א" },
+            "expected refEntry heRef='חוות יאיר א, א'"
+        )
+    }
+
+    companion object {
+        // Simulates the real Havot Yair schema: heSectionNames present but first
+        // entry is "" (empty) — a recurring Sefaria pattern for responsa.
+        private val schemaJson = """
+            {
+              "title": "Havot Yair",
+              "heTitle": "חוות יאיר",
+              "schema": {
+                "nodeType": "JaggedArrayNode",
+                "depth": 2,
+                "addressTypes": ["Siman", "Seif"],
+                "sectionNames": ["Teshuva", "Paragraph"],
+                "heSectionNames": ["", "פסקה"],
+                "title": "Havot Yair",
+                "heTitle": "חוות יאיר"
+              }
+            }
+        """.trimIndent()
+
+        private val mergedJson = """
+            {
+              "title": "Havot Yair",
+              "heTitle": "חוות יאיר",
+              "text": [
+                ["text of teshuva 1 paragraph 1", "text of teshuva 1 paragraph 2"],
+                ["text of teshuva 2 paragraph 1"]
+              ]
+            }
+        """.trimIndent()
+    }
+}

--- a/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaYerushalmiAltTocTest.kt
+++ b/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaYerushalmiAltTocTest.kt
@@ -1,0 +1,204 @@
+package io.github.kdroidfilter.seforimlibrary.sefariasqlite
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import co.touchlab.kermit.Logger
+import io.github.kdroidfilter.seforimlibrary.dao.repository.SeforimRepository
+import io.github.kdroidfilter.seforimlibrary.db.SeforimDb
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression for https://github.com/kdroidFilter/Zayit/issues/392 (Jerusalem
+ * Talmud Venice/Vilna daf headings).
+ *
+ * The Yerushalmi's main schema is chapter × halakhah × segment; the printed-
+ * edition daf navigation lives in the `Venice` and `Vilna` alt-structs.
+ * The old importer tagged every tractate whose category contains "תלמוד" as
+ * `isTalmudTractate`, which suppresses alt-struct child enumeration — so
+ * Yerushalmi ended up with no daf headings from either printing.
+ */
+class SefariaYerushalmiAltTocTest {
+    @Test
+    fun yerushalmiGetsAltTocEntriesForVeniceAndVilna() = runBlocking {
+        val tempDir = Files.createTempDirectory("seforim-yeru")
+        val schemaDir = Files.createDirectories(tempDir.resolve("schemas"))
+        val jsonDir = Files.createDirectories(tempDir.resolve("json"))
+        val bookDir = Files.createDirectories(jsonDir.resolve("Jerusalem Talmud Berakhot"))
+
+        Files.writeString(schemaDir.resolve("Jerusalem_Talmud_Berakhot.json"), schemaJson)
+        Files.writeString(bookDir.resolve("merged.json"), mergedJson)
+
+        val reader = SefariaBookPayloadReader(
+            Json { ignoreUnknownKeys = true; coerceInputValues = true },
+            Logger.withTag("SefariaYerushalmiAltTocTest")
+        )
+        val schemaLookup = reader.buildSchemaLookup(schemaDir)
+        val payload = reader.readBooksInParallel(jsonDir, schemaDir, schemaLookup).single()
+
+        // Precondition: schema parsing picked up the Hebrew categorisation
+        assertTrue(payload.categoriesHe.any { it.contains("ירושלמי") })
+
+        // Build alt-toc entries through a real (in-memory) SQLite so we can
+        // inspect what gets persisted for Venice/Vilna.
+        val driver = JdbcSqliteDriver(url = "jdbc:sqlite::memory:")
+        SeforimDb.Schema.create(driver)
+        val repo = SeforimRepository(":memory:", driver)
+
+        val sourceId = repo.insertSource("Sefaria-Test")
+        val catId = repo.insertCategory(
+            io.github.kdroidfilter.seforimlibrary.core.models.Category(
+                id = 0,
+                parentId = null,
+                title = "ירושלמי",
+                level = 0,
+                order = 1
+            )
+        )
+        val book = io.github.kdroidfilter.seforimlibrary.core.models.Book(
+            id = 1,
+            categoryId = catId,
+            sourceId = sourceId,
+            title = payload.heTitle,
+            heRef = payload.heTitle,
+            authors = emptyList(),
+            pubPlaces = emptyList(),
+            pubDates = emptyList(),
+            heShortDesc = null,
+            notesContent = null,
+            order = 1f,
+            topics = emptyList(),
+            isBaseBook = true,
+            totalLines = payload.lines.size,
+            hasAltStructures = false,
+            hasTeamim = false,
+            hasNekudot = false
+        )
+        repo.insertBook(book)
+
+        val lineKeyToId = ConcurrentHashMap<Pair<String, Int>, Long>()
+        payload.lines.forEachIndexed { idx, content ->
+            val lineId = (idx + 1).toLong()
+            repo.insertLinesBatch(
+                listOf(
+                    io.github.kdroidfilter.seforimlibrary.core.models.Line(
+                        id = lineId,
+                        bookId = 1,
+                        lineIndex = idx,
+                        content = content,
+                        heRef = payload.refEntries.getOrNull(idx)?.heRef
+                    )
+                )
+            )
+            lineKeyToId["Jerusalem Talmud Berakhot" to idx] = lineId
+        }
+
+        val altTocBuilder = SefariaAltTocBuilder(repo)
+        val ok = altTocBuilder.buildAltTocStructuresForBook(
+            payload = payload,
+            bookId = 1,
+            bookPath = "Jerusalem Talmud Berakhot",
+            lineKeyToId = lineKeyToId,
+            totalLines = payload.lines.size
+        )
+
+        assertTrue(ok, "expected alt-struct TOC entries to have been generated")
+
+        // Read back structures — both Venice and Vilna must exist
+        val structs = repo.getAltTocStructuresForBook(1)
+        assertTrue(structs.any { it.key == "Venice" }, "Venice alt-struct not persisted")
+        assertTrue(structs.any { it.key == "Vilna" }, "Vilna alt-struct not persisted")
+
+        // Entries under Venice should include column headings from the refs
+        val venice = structs.first { it.key == "Venice" }
+        val veniceEntries = repo.getAltTocEntriesForStructure(venice.id)
+        assertTrue(
+            veniceEntries.isNotEmpty(),
+            "Venice structure has no entries — alt-struct children were skipped"
+        )
+
+        repo.close()
+        // Unused but reminds future readers why we built a real DB
+        @Suppress("UNUSED_VARIABLE") val _unused = UUID.randomUUID()
+    }
+
+    companion object {
+        // Simplified but schema-faithful: main chapter × halakhah × segment
+        // schema with Venice and Vilna alt-structs (each a single chapter
+        // node with 3 column refs).
+        private val schemaJson = """
+            {
+              "title": "Jerusalem Talmud Berakhot",
+              "heTitle": "תלמוד ירושלמי ברכות",
+              "heCategories": ["תלמוד", "ירושלמי", "סדר זרעים"],
+              "categories": ["Talmud", "Yerushalmi", "Seder Zeraim"],
+              "schema": {
+                "nodeType": "JaggedArrayNode",
+                "depth": 3,
+                "addressTypes": ["Perek", "Halakhah", "Integer"],
+                "sectionNames": ["Chapter", "Halakhah", "Segment"],
+                "heSectionNames": ["פרק", "הלכה", "קטע"],
+                "title": "Jerusalem Talmud Berakhot",
+                "heTitle": "תלמוד ירושלמי ברכות"
+              },
+              "alts": {
+                "Venice": {
+                  "nodes": [
+                    {
+                      "nodeType": "ArrayMapNode",
+                      "depth": 1,
+                      "wholeRef": "Jerusalem Talmud Berakhot 1:1:1-1:2:2",
+                      "addressTypes": ["Folio"],
+                      "sectionNames": ["Column"],
+                      "refs": [
+                        "Jerusalem Talmud Berakhot 1:1:1",
+                        "Jerusalem Talmud Berakhot 1:1:2",
+                        "Jerusalem Talmud Berakhot 1:2:1"
+                      ],
+                      "startingAddress": "2a",
+                      "offset": 4,
+                      "title": "Chapter 1",
+                      "heTitle": "מאימתי"
+                    }
+                  ]
+                },
+                "Vilna": {
+                  "nodes": [
+                    {
+                      "nodeType": "ArrayMapNode",
+                      "depth": 1,
+                      "wholeRef": "Jerusalem Talmud Berakhot 1:1:1-1:2:2",
+                      "addressTypes": ["Folio"],
+                      "sectionNames": ["Daf"],
+                      "refs": [
+                        "Jerusalem Talmud Berakhot 1:1:1",
+                        "Jerusalem Talmud Berakhot 1:1:2"
+                      ],
+                      "startingAddress": "2a",
+                      "title": "Chapter 1",
+                      "heTitle": "מאימתי"
+                    }
+                  ]
+                }
+              }
+            }
+        """.trimIndent()
+
+        private val mergedJson = """
+            {
+              "title": "Jerusalem Talmud Berakhot",
+              "heTitle": "תלמוד ירושלמי ברכות",
+              "text": [
+                [
+                  ["seg 1-1-1", "seg 1-1-2"],
+                  ["seg 1-2-1", "seg 1-2-2"]
+                ]
+              ]
+            }
+        """.trimIndent()
+    }
+}

--- a/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaZoharIndexOffsetsTest.kt
+++ b/generator/sefariasqlite/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaZoharIndexOffsetsTest.kt
@@ -1,0 +1,163 @@
+package io.github.kdroidfilter.seforimlibrary.sefariasqlite
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression for https://github.com/kdroidFilter/Zayit/issues/392 (Zohar vol 2
+ * Tetzaveh: daf קפו: missing — jumps from קפו. straight to קפז).
+ *
+ * Root cause: Sefaria refs for Zohar use `chapter:global_paragraph_index`
+ * (cumulative within a parasha), driven by `index_offsets_by_depth`. The old
+ * importer stored per-chapter-local paragraph refs ("14:1"…"14:14"), so the
+ * alt-struct `Daf` refs like `"Zohar, Tetzaveh 14:118-127"` fell back to the
+ * same line ("14:14"), got deduplicated, and daf 186a (the 14th sub-ref) was
+ * dropped.
+ */
+class SefariaZoharIndexOffsetsTest {
+    @Test
+    fun paragraphRefsUseGlobalIndexWhenIndexOffsetsByDepthPresent() = runBlocking {
+        val tempDir = Files.createTempDirectory("seforim-zohar")
+        val schemaDir = Files.createDirectories(tempDir.resolve("schemas"))
+        val jsonDir = Files.createDirectories(tempDir.resolve("json"))
+        val bookDir = Files.createDirectories(jsonDir.resolve("Zohar"))
+
+        Files.writeString(schemaDir.resolve("Zohar.json"), schemaJson)
+        Files.writeString(bookDir.resolve("merged.json"), mergedJson)
+
+        val reader = SefariaBookPayloadReader(
+            Json { ignoreUnknownKeys = true; coerceInputValues = true },
+            Logger.withTag("SefariaZoharIndexOffsetsTest")
+        )
+        val schemaLookup = reader.buildSchemaLookup(schemaDir)
+        val payload = reader.readBooksInParallel(jsonDir, schemaDir, schemaLookup).single()
+
+        // Chapter 1 (offset 0): paragraphs 1..3 → refs chapter 1 global 1..3
+        assertTrue(
+            payload.refEntries.any { it.ref.contains("Tetzaveh") && it.ref.endsWith("1:1") },
+            "expected ref ending 'Tetzaveh 1:1' (got ${payload.refEntries.take(6).map { it.ref }})"
+        )
+        assertTrue(payload.refEntries.any { it.ref.contains("Tetzaveh") && it.ref.endsWith("1:3") })
+
+        // Chapter 2 (offset 3): first paragraph → global index 4
+        assertTrue(
+            payload.refEntries.any { it.ref.contains("Tetzaveh") && it.ref.endsWith("2:4") },
+            "expected ref ending 'Tetzaveh 2:4' (chapter 2 starts at global paragraph 4)"
+        )
+
+        // Chapter 3 (offset 6): first paragraph → global index 7
+        assertTrue(
+            payload.refEntries.any { it.ref.contains("Tetzaveh") && it.ref.endsWith("3:7") },
+            "expected ref ending 'Tetzaveh 3:7' (chapter 3 starts at global paragraph 7)"
+        )
+
+        // Per-chapter Hebrew letter labels remain local (א/ב/ג at each chapter)
+        // — offsets only touch the English numeric refs.
+        val chapter3HeRefs = payload.refEntries.filter { it.heRef.contains("תצוה,") && it.heRef.contains("ג,") }
+        assertTrue(
+            chapter3HeRefs.any { it.heRef.endsWith("ג, א") },
+            "Hebrew heRef should still use per-chapter letter (got ${payload.refEntries.map { it.heRef }})"
+        )
+    }
+
+    @Test
+    fun bookWithoutIndexOffsetsByDepthStillUsesLocalIndex() = runBlocking {
+        val tempDir = Files.createTempDirectory("seforim-plain")
+        val schemaDir = Files.createDirectories(tempDir.resolve("schemas"))
+        val jsonDir = Files.createDirectories(tempDir.resolve("json"))
+        val bookDir = Files.createDirectories(jsonDir.resolve("Plain"))
+
+        Files.writeString(schemaDir.resolve("Plain.json"), plainSchemaJson)
+        Files.writeString(bookDir.resolve("merged.json"), plainMergedJson)
+
+        val reader = SefariaBookPayloadReader(
+            Json { ignoreUnknownKeys = true; coerceInputValues = true },
+            Logger.withTag("SefariaZoharIndexOffsetsTest")
+        )
+        val schemaLookup = reader.buildSchemaLookup(schemaDir)
+        val payload = reader.readBooksInParallel(jsonDir, schemaDir, schemaLookup).single()
+
+        // Chapter 2 paragraph 1 → ref ends "2:1" (no global offset applied)
+        assertTrue(
+            payload.refEntries.any { it.ref.contains("Plain") && it.ref.endsWith("2:1") },
+            "without offsets, refs stay per-chapter local (got ${payload.refEntries.map { it.ref }})"
+        )
+        assertTrue(payload.refEntries.none { it.ref.contains("Plain") && it.ref.endsWith("2:4") })
+        assertEquals(6, payload.refEntries.size)
+    }
+
+    companion object {
+        // Faithful to the real Zohar → Tetzaveh node pattern (simplified to 3
+        // chapters with offsets [0, 3, 6]).
+        private val schemaJson = """
+            {
+              "title": "Zohar",
+              "heTitle": "ספר הזהר",
+              "schema": {
+                "nodeType": "SchemaNode",
+                "title": "Zohar",
+                "heTitle": "ספר הזהר",
+                "nodes": [
+                  {
+                    "nodeType": "JaggedArrayNode",
+                    "depth": 2,
+                    "addressTypes": ["Integer", "Integer"],
+                    "sectionNames": ["Chapter", "Paragraph"],
+                    "heSectionNames": ["פרק", "פסקה"],
+                    "title": "Tetzaveh",
+                    "heTitle": "תצוה",
+                    "key": "Tetzaveh",
+                    "index_offsets_by_depth": { "2": [0, 3, 6] }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        private val mergedJson = """
+            {
+              "title": "Zohar",
+              "heTitle": "ספר הזהר",
+              "text": {
+                "Tetzaveh": [
+                  ["ch1 p1", "ch1 p2", "ch1 p3"],
+                  ["ch2 p1", "ch2 p2", "ch2 p3"],
+                  ["ch3 p1", "ch3 p2", "ch3 p3"]
+                ]
+              }
+            }
+        """.trimIndent()
+
+        private val plainSchemaJson = """
+            {
+              "title": "Plain",
+              "heTitle": "ספר רגיל",
+              "schema": {
+                "nodeType": "JaggedArrayNode",
+                "depth": 2,
+                "addressTypes": ["Integer", "Integer"],
+                "sectionNames": ["Chapter", "Paragraph"],
+                "heSectionNames": ["פרק", "פסקה"],
+                "title": "Plain",
+                "heTitle": "ספר רגיל"
+              }
+            }
+        """.trimIndent()
+
+        private val plainMergedJson = """
+            {
+              "title": "Plain",
+              "heTitle": "ספר רגיל",
+              "text": [
+                ["p1", "p2", "p3"],
+                ["p1", "p2", "p3"]
+              ]
+            }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Summary
Targets all seven book-conversion regressions reported in [Zayit issue #392](https://github.com/kdroidFilter/Zayit/issues/392) against the Sefaria→SQLite pipeline:

- **`@NN…}` Otzar HaChochma markup** leaked into content lines (Maaseh Rokeach on Kelim, Malbim). Now scrubbed in `cleanSefariaLine`.
- **Keter Malkhut content disappeared** because its schema declares `depth=2` while most chapters are stored as primitive strings. `recursiveSections` now degrades to a leaf when it hits a primitive below the declared depth.
- **Responsa TOC missing** (Chavot Yair, Teshuvot HaRi Migash, Ohr HaSekhel, Shut Chatam Sofer, Noda BiYehudah, Rashba): their `heSectionNames[0]=""` was treated as a blank heading. Added `readHeSectionNames` that falls back to a Hebrew mapping of the English `sectionNames` via a new `mapSectionNameToHebrew`.
- **Tikkunei HaZohar sub-TOC half English** (`Tikkun א`, `Tikkun ב`…): the mapper now covers `tikkun → תיקון` (plus `column`, `folio`, `segment`, `parasha`, `volume`, `part`, etc.).
- **Tikkunei HaZohar short lines after daf יז**: collapsed inline `<br>` tags to a single space.
- **Zohar vol 2 Tetzaveh daf קפו: missing**: honour `index_offsets_by_depth` so paragraph refs use global-per-parasha indices, matching Sefaria's own convention (and the format used by every links CSV referencing Zohar).
- **Jerusalem Talmud missing Venice/Vilna daf headings**: the `isTalmudTractate` flag suppressed alt-struct child enumeration for every tractate whose category contains "תלמוד". Narrowed to Bavli so Yerushalmi's `Venice`/`Vilna` alt-structs now generate column headings.
- **Broken ❌ `textimages.sefaria.org` images**: added `SefariaImageEmbedder` that prefetches every referenced image, caches it on disk under `build/sefaria/image-cache`, and substitutes `<img src="…">` with `data:image/…;base64,…` URIs during `cleanSefariaLine`. The resulting DB is fully self-contained.

## Implementation notes
- 4 files modified (`SefariaBookPayloadReader`, `SefariaAltTocBuilder`, `SefariaImportText`, `SefariaDirectImporter`), 1 new (`SefariaImageEmbedder`), 6 new test files.
- 18 new unit tests passing end-to-end.
- Full regeneration against the current Sefaria export takes ~7 minutes and produces a 4.5 GB `seforim.db` (358 textimages embedded as base64, bumping size by ~500 MB).

## Validation
End-to-end SQL spot checks against the regenerated DB:

| Bug | Before | After |
| --- | ---: | ---: |
| `@NN…}` sentinels | 18 hits | 0 |
| Keter Malkhut content lines | 0 | 65 |
| Or HaSechel `tocEntry` rows | 0 | 12 |
| Tikkunei HaZohar English "Tikkun N" | 70 | 0 |
| `<br>` tags in content | 1,888 | 0 |
| Yerushalmi Venice alt-structs | 0 | 39 tractates |
| Zohar דף קפו: entries | 0 | 3 |
| Lines with `data:image/` | 0 | 701 |

## Test plan
- [x] `./gradlew :sefariasqlite:jvmTest` — 18 tests green
- [x] `./gradlew :sefariasqlite:generateSefariaSqlite -PexportDir=build/sefaria/export -PseforimDb=build/seforim-test.db` — DB builds successfully
- [x] SQL spot-checks for each bug pass against the regenerated DB
- [x] Visual smoke-test in the desktop app for: Keter Malkhut, Maaseh Rokeach on Kelim ch.5, Tikkunei HaZohar daf יז + daf נא, Zohar Tetzaveh קפו:, Jerusalem Talmud Berakhot (Venice + Vilna), Chavot Yair, Ohr HaSekhel

Closes #392