### PR TITLE
fix(link): order commentaries by target line index

### DIFF
--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/core/models/Link.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/core/models/Link.kt
@@ -10,6 +10,9 @@ import kotlinx.serialization.Serializable
  * @property targetBookId The identifier of the target book
  * @property sourceLineId The identifier of the source line
  * @property targetLineId The identifier of the target line
+ * @property targetLineIndex The 0-based index of the target line within its book.
+ *           Denormalized from `line.lineIndex` so that commentaries can be ordered
+ *           by their natural position in the target book without an extra JOIN.
  * @property connectionType The type of connection between the texts
  */
 @Serializable
@@ -19,6 +22,7 @@ data class Link(
     val targetBookId: Long,
     val sourceLineId: Long,
     val targetLineId: Long,
+    val targetLineIndex: Int,
     val connectionType: ConnectionType
 )
 

--- a/dao/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/dao/extensions/ModelExtensions.kt
+++ b/dao/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/dao/extensions/ModelExtensions.kt
@@ -346,6 +346,7 @@ fun io.github.kdroidfilter.seforimlibrary.db.SelectLinkById.toModel(): Link {
         targetBookId = targetBookId,
         sourceLineId = sourceLineId,
         targetLineId = targetLineId,
+        targetLineIndex = targetLineIndex.toInt(),
         connectionType = ConnectionType.fromString(connectionType)
     )
 }
@@ -362,6 +363,7 @@ fun io.github.kdroidfilter.seforimlibrary.db.SelectLinksBySourceLineIds.toModel(
         targetBookId = targetBookId,
         sourceLineId = sourceLineId,
         targetLineId = targetLineId,
+        targetLineIndex = targetLineIndex.toInt(),
         connectionType = ConnectionType.fromString(connectionType)
     )
 }
@@ -378,6 +380,7 @@ fun io.github.kdroidfilter.seforimlibrary.db.SelectLinksBySourceBook.toModel(): 
         targetBookId = targetBookId,
         sourceLineId = sourceLineId,
         targetLineId = targetLineId,
+        targetLineIndex = targetLineIndex.toInt(),
         connectionType = ConnectionType.fromString(connectionType)
     )
 }

--- a/dao/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/dao/repository/SeforimRepository.kt
+++ b/dao/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/dao/repository/SeforimRepository.kt
@@ -1549,6 +1549,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                         targetBookId = it.targetBookId,
                         sourceLineId = it.sourceLineId,
                         targetLineId = it.targetLineId,
+                        targetLineIndex = it.targetLineIndex.toInt(),
                         connectionType = ConnectionType.fromString(it.connectionType)
                     ),
                     targetBookTitle = it.targetBookTitle,
@@ -1574,6 +1575,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                         targetBookId = it.targetBookId,
                         sourceLineId = it.sourceLineId,
                         targetLineId = it.targetLineId,
+                        targetLineIndex = it.targetLineIndex.toInt(),
                         connectionType = ConnectionType.fromString(it.connectionType)
                     ),
                     targetBookTitle = it.targetBookTitle
@@ -1623,6 +1625,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                             targetBookId = it.targetBookId,
                             sourceLineId = it.sourceLineId ?: 0L,
                             targetLineId = it.targetLineId,
+                            targetLineIndex = (it.targetLineIndex ?: 0L).toInt(),
                             connectionType = ConnectionType.fromString(it.connectionType)
                         ),
                         targetBookTitle = it.targetBookTitle,
@@ -1643,6 +1646,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                             targetBookId = it.targetBookId,
                             sourceLineId = it.sourceLineId,
                             targetLineId = it.targetLineId,
+                            targetLineIndex = it.targetLineIndex.toInt(),
                             connectionType = ConnectionType.fromString(it.connectionType)
                         ),
                         targetBookTitle = it.targetBookTitle,
@@ -1666,6 +1670,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                             targetBookId = it.targetBookId,
                             sourceLineId = it.sourceLineId ?: 0L,
                             targetLineId = it.targetLineId,
+                            targetLineIndex = (it.targetLineIndex ?: 0L).toInt(),
                             connectionType = ConnectionType.fromString(it.connectionType)
                         ),
                         targetBookTitle = it.targetBookTitle,
@@ -1687,6 +1692,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                             targetBookId = it.targetBookId,
                             sourceLineId = it.sourceLineId,
                             targetLineId = it.targetLineId,
+                            targetLineIndex = it.targetLineIndex.toInt(),
                             connectionType = ConnectionType.fromString(it.connectionType)
                         ),
                         targetBookTitle = it.targetBookTitle,
@@ -1750,6 +1756,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                 targetBookId = link.targetBookId,
                 sourceLineId = link.sourceLineId,
                 targetLineId = link.targetLineId,
+                targetLineIndex = link.targetLineIndex.toLong(),
                 connectionTypeId = connectionTypeId
             )
             val linkId = database.linkQueriesQueries.lastInsertRowId().executeAsOne()
@@ -1808,6 +1815,7 @@ class SeforimRepository(databasePath: String, private val driver: SqlDriver) : L
                     targetBookId = link.targetBookId,
                     sourceLineId = link.sourceLineId,
                     targetLineId = link.targetLineId,
+                    targetLineIndex = link.targetLineIndex.toLong(),
                     connectionTypeId = connectionTypeId
                 )
             }

--- a/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/Database.sq
+++ b/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/Database.sq
@@ -199,12 +199,15 @@ CREATE TABLE IF NOT EXISTS connection_type (
 CREATE INDEX IF NOT EXISTS idx_connection_type_name ON connection_type(name);
 
 -- Links table
+-- targetLineIndex mirrors line(targetLineId).lineIndex so we can sort commentaries
+-- by their natural position in the target book without an extra JOIN on `line`.
 CREATE TABLE IF NOT EXISTS link (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     sourceBookId INTEGER NOT NULL,
     targetBookId INTEGER NOT NULL,
     sourceLineId INTEGER NOT NULL,
     targetLineId INTEGER NOT NULL,
+    targetLineIndex INTEGER NOT NULL,
     connectionTypeId INTEGER NOT NULL,
     FOREIGN KEY (sourceBookId) REFERENCES book(id) ON DELETE CASCADE,
     FOREIGN KEY (targetBookId) REFERENCES book(id) ON DELETE CASCADE,
@@ -219,6 +222,7 @@ CREATE INDEX IF NOT EXISTS idx_link_target_book ON link(targetBookId);
 CREATE INDEX IF NOT EXISTS idx_link_target_line ON link(targetLineId);
 CREATE INDEX IF NOT EXISTS idx_link_type ON link(connectionTypeId);
 CREATE INDEX IF NOT EXISTS idx_link_type_source_line ON link(connectionTypeId, sourceLineId);
+CREATE INDEX IF NOT EXISTS idx_link_type_source_order ON link(connectionTypeId, sourceLineId, targetLineIndex);
 
 -- Removed legacy FTS view/table in favor of Lucene (10.x)
 

--- a/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/LinkQueries.sq
+++ b/dao/src/commonMain/sqldelight/io/github/kdroidfilter/seforimlibrary/db/LinkQueries.sq
@@ -16,7 +16,7 @@ JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 JOIN line tl ON l.targetLineId = tl.id
 WHERE l.sourceLineId IN ?
-ORDER BY b.orderIndex;
+ORDER BY b.orderIndex, l.targetLineIndex;
 
 selectLinksBySourceLineIdsPaged:
 SELECT l.*, ct.name AS connectionType, b.title AS targetBookTitle, tl.content AS targetText
@@ -25,7 +25,7 @@ JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 JOIN line tl ON l.targetLineId = tl.id
 WHERE l.sourceLineId IN ?
-ORDER BY b.orderIndex
+ORDER BY b.orderIndex, l.targetLineIndex
 LIMIT ? OFFSET ?;
 
 selectLinksBySourceLineIdsAndTargetsPaged:
@@ -35,7 +35,7 @@ JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 JOIN line tl ON l.targetLineId = tl.id
 WHERE l.sourceLineId IN ? AND l.targetBookId IN ?
-ORDER BY b.orderIndex
+ORDER BY b.orderIndex, l.targetLineIndex
 LIMIT ? OFFSET ?;
 
 selectLinksBySourceLineIdsAndTypesPaged:
@@ -45,18 +45,18 @@ JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 JOIN line tl ON l.targetLineId = tl.id
 WHERE l.sourceLineId IN ? AND ct.name IN ?
-ORDER BY b.orderIndex
+ORDER BY b.orderIndex, l.targetLineIndex
 LIMIT ? OFFSET ?;
 
 selectLinksBySourceLineIdsAndTypesPagedDistinct:
-SELECT MIN(l.id) AS id, MIN(l.sourceBookId) AS sourceBookId, l.targetBookId, MIN(l.sourceLineId) AS sourceLineId, l.targetLineId, MIN(l.connectionTypeId) AS connectionTypeId, ct.name AS connectionType, b.title AS targetBookTitle, tl.content AS targetText
+SELECT MIN(l.id) AS id, MIN(l.sourceBookId) AS sourceBookId, l.targetBookId, MIN(l.sourceLineId) AS sourceLineId, l.targetLineId, MIN(l.targetLineIndex) AS targetLineIndex, MIN(l.connectionTypeId) AS connectionTypeId, ct.name AS connectionType, b.title AS targetBookTitle, tl.content AS targetText
 FROM link l
 JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 JOIN line tl ON l.targetLineId = tl.id
 WHERE l.sourceLineId IN ? AND ct.name IN ?
 GROUP BY l.targetLineId
-ORDER BY b.orderIndex
+ORDER BY b.orderIndex, MIN(l.targetLineIndex)
 LIMIT ? OFFSET ?;
 
 selectLinksBySourceLineIdsTargetsAndTypesPaged:
@@ -66,18 +66,18 @@ JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 JOIN line tl ON l.targetLineId = tl.id
 WHERE l.sourceLineId IN ? AND l.targetBookId IN ? AND ct.name IN ?
-ORDER BY b.orderIndex
+ORDER BY b.orderIndex, l.targetLineIndex
 LIMIT ? OFFSET ?;
 
 selectLinksBySourceLineIdsTargetsAndTypesPagedDistinct:
-SELECT MIN(l.id) AS id, MIN(l.sourceBookId) AS sourceBookId, l.targetBookId, MIN(l.sourceLineId) AS sourceLineId, l.targetLineId, MIN(l.connectionTypeId) AS connectionTypeId, ct.name AS connectionType, b.title AS targetBookTitle, tl.content AS targetText
+SELECT MIN(l.id) AS id, MIN(l.sourceBookId) AS sourceBookId, l.targetBookId, MIN(l.sourceLineId) AS sourceLineId, l.targetLineId, MIN(l.targetLineIndex) AS targetLineIndex, MIN(l.connectionTypeId) AS connectionTypeId, ct.name AS connectionType, b.title AS targetBookTitle, tl.content AS targetText
 FROM link l
 JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 JOIN line tl ON l.targetLineId = tl.id
 WHERE l.sourceLineId IN ? AND l.targetBookId IN ? AND ct.name IN ?
 GROUP BY l.targetLineId
-ORDER BY b.orderIndex
+ORDER BY b.orderIndex, MIN(l.targetLineIndex)
 LIMIT ? OFFSET ?;
 
 selectLinkSummariesBySourceLineIds:
@@ -86,7 +86,7 @@ FROM link l
 JOIN connection_type ct ON l.connectionTypeId = ct.id
 JOIN book b ON l.targetBookId = b.id
 WHERE l.sourceLineId IN ?
-ORDER BY b.orderIndex;
+ORDER BY b.orderIndex, l.targetLineIndex;
 
 selectLinksBySourceBook:
 SELECT l.*, ct.name AS connectionType
@@ -107,8 +107,8 @@ GROUP BY l.targetBookId, b.title, a.name
 ORDER BY b.orderIndex, b.title;
 
 insert:
-INSERT INTO link (sourceBookId, targetBookId, sourceLineId, targetLineId, connectionTypeId)
-VALUES (?, ?, ?, ?, ?);
+INSERT INTO link (sourceBookId, targetBookId, sourceLineId, targetLineId, targetLineIndex, connectionTypeId)
+VALUES (?, ?, ?, ?, ?, ?);
 
 delete:
 DELETE FROM link WHERE id = ?;

--- a/dao/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/dao/repository/SeforimRepositoryIntegrationTest.kt
+++ b/dao/src/jvmTest/kotlin/io/github/kdroidfilter/seforimlibrary/dao/repository/SeforimRepositoryIntegrationTest.kt
@@ -3,7 +3,9 @@ package io.github.kdroidfilter.seforimlibrary.dao.repository
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import io.github.kdroidfilter.seforimlibrary.core.models.Book
 import io.github.kdroidfilter.seforimlibrary.core.models.Category
+import io.github.kdroidfilter.seforimlibrary.core.models.ConnectionType
 import io.github.kdroidfilter.seforimlibrary.core.models.Line
+import io.github.kdroidfilter.seforimlibrary.core.models.Link
 import io.github.kdroidfilter.seforimlibrary.core.models.TocEntry
 import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
@@ -449,6 +451,67 @@ class SeforimRepositoryIntegrationTest {
         val maxId = repository.getMaxLineId()
         assertEquals(0L, maxId)
     }
+
+    // ==================== Link Ordering Tests ====================
+
+    // Regression guard for Zayit issue #415: commentary links must be returned in the
+    // natural order of their target line (e.g. Bartenura segments 1→N on a single Mishna),
+    // not in link insertion order.
+    @Test
+    fun `getCommentariesForLineRange returns links sorted by targetLineIndex`() = runBlocking {
+        val sourceId = repository.insertSource("Test")
+        val mishnahCategoryId = repository.insertCategory(
+            Category(parentId = null, title = "Mishnah", level = 0, order = 1)
+        )
+        val mishnahBookId = repository.insertBook(
+            Book(categoryId = mishnahCategoryId, sourceId = sourceId, title = "Avot", order = 1f)
+        )
+        val bartenuraBookId = repository.insertBook(
+            Book(categoryId = mishnahCategoryId, sourceId = sourceId, title = "Bartenura on Avot", order = 2f)
+        )
+
+        val mishnaLineId = repository.insertLine(
+            Line(bookId = mishnahBookId, lineIndex = 0, content = "Mishna Avot 1:1")
+        )
+
+        val bartenuraSegmentIds = (0 until 5).map { idx ->
+            repository.insertLine(
+                Line(bookId = bartenuraBookId, lineIndex = idx, content = "Segment $idx")
+            )
+        }
+
+        // Insert links in a deliberately shuffled order (4, 2, 0, 3, 1) to prove the
+        // ordering comes from targetLineIndex, not insertion order.
+        val shuffledOrder = listOf(4, 2, 0, 3, 1)
+        for (idx in shuffledOrder) {
+            repository.insertLink(
+                Link(
+                    sourceBookId = mishnahBookId,
+                    targetBookId = bartenuraBookId,
+                    sourceLineId = mishnaLineId,
+                    targetLineId = bartenuraSegmentIds[idx],
+                    targetLineIndex = idx,
+                    connectionType = ConnectionType.COMMENTARY
+                )
+            )
+        }
+
+        val commentaries = repository.getCommentariesForLineRange(
+            lineIds = listOf(mishnaLineId),
+            connectionTypes = setOf(ConnectionType.COMMENTARY),
+            offset = 0,
+            limit = 100
+        )
+
+        assertEquals(5, commentaries.size)
+        assertEquals(listOf(0, 1, 2, 3, 4), commentaries.map { it.link.targetLineIndex })
+        assertEquals(
+            listOf("Segment 0", "Segment 1", "Segment 2", "Segment 3", "Segment 4"),
+            commentaries.map { it.targetText }
+        )
+    }
+
+    // ==================== Max ID Tests (continued) ====================
 
     @Test
     fun `getMaxLineId returns highest line id`() = runBlocking {

--- a/generator/otzariasqlite/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/otzariasqlite/Generator.kt
+++ b/generator/otzariasqlite/src/commonMain/kotlin/io/github/kdroidfilter/seforimlibrary/otzariasqlite/Generator.kt
@@ -1320,6 +1320,7 @@ class DatabaseGenerator(
                         targetBookId = targetBook.id,
                         sourceLineId = sourceLineId,
                         targetLineId = targetLineId,
+                        targetLineIndex = targetLineIndex,
                         connectionType = ConnectionType.fromString(linkData.connectionType)
                     )
 
@@ -1394,6 +1395,7 @@ class DatabaseGenerator(
                     targetBookId = targetBook.id,
                     sourceLineId = sourceLineId,
                     targetLineId = targetLineId,
+                    targetLineIndex = targetLineIndex,
                     connectionType = ConnectionType.fromString(linkData.connectionType)
                 )
                 repository.insertLink(link)

--- a/generator/otzariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/otzariasqlite/GenerateHavroutaLinks.kt
+++ b/generator/otzariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/otzariasqlite/GenerateHavroutaLinks.kt
@@ -275,6 +275,7 @@ private suspend fun processBookPair(
             targetBookId = havroutaBookId,
             sourceLineId = talmudLineId,
             targetLineId = havroutaLine.id,
+            targetLineIndex = havroutaLine.lineIndex,
             connectionType = ConnectionType.COMMENTARY
         ))
 
@@ -284,6 +285,7 @@ private suspend fun processBookPair(
             targetBookId = talmudBookId,
             sourceLineId = havroutaLine.id,
             targetLineId = talmudLineId,
+            targetLineIndex = matchingLineIndex,
             connectionType = ConnectionType.SOURCE
         ))
 
@@ -573,6 +575,7 @@ private suspend fun generateHavroutaHearotLinks(
                 targetBookId = targetBook.id,
                 sourceLineId = sourceLineId,
                 targetLineId = targetLineId,
+                targetLineIndex = targetLineIndex,
                 connectionType = ConnectionType.COMMENTARY
             ))
 
@@ -582,6 +585,7 @@ private suspend fun generateHavroutaHearotLinks(
                 targetBookId = havroutaBook.id,
                 sourceLineId = targetLineId,
                 targetLineId = sourceLineId,
+                targetLineIndex = sourceLineIndex,
                 connectionType = ConnectionType.SOURCE
             ))
         }
@@ -669,12 +673,13 @@ private suspend fun generateTalmudHearotTransitiveLinks(
     logger.i { "Creating transitive Talmud->Hearot links via SQL..." }
 
     val insertSql = """
-        INSERT INTO link (sourceBookId, targetBookId, sourceLineId, targetLineId, connectionTypeId)
+        INSERT INTO link (sourceBookId, targetBookId, sourceLineId, targetLineId, targetLineIndex, connectionTypeId)
         SELECT DISTINCT
             l1.sourceBookId,
             l2.targetBookId,
             l1.sourceLineId,
             l2.targetLineId,
+            l2.targetLineIndex,
             ct.id
         FROM link l1
         JOIN link l2 ON l1.targetLineId = l2.sourceLineId

--- a/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaLinksImporter.kt
+++ b/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SefariaLinksImporter.kt
@@ -107,8 +107,10 @@ internal class SefariaLinksImporter(
 
                 for (from in fromRefs) {
                     for (to in toRefs) {
-                        val srcLine = lineKeyToId[from.path to (from.lineIndex - 1)] ?: continue
-                        val tgtLine = lineKeyToId[to.path to (to.lineIndex - 1)] ?: continue
+                        val srcLineIndex = from.lineIndex - 1
+                        val tgtLineIndex = to.lineIndex - 1
+                        val srcLine = lineKeyToId[from.path to srcLineIndex] ?: continue
+                        val tgtLine = lineKeyToId[to.path to tgtLineIndex] ?: continue
                         // Skip links where source or target is a heading line
                         if (srcLine in headingLineIds || tgtLine in headingLineIds) continue
                         val baseConnectionType = ConnectionType.fromString(conn)
@@ -140,6 +142,7 @@ internal class SefariaLinksImporter(
                                 targetBookId = tgtBookId,
                                 sourceLineId = srcLine,
                                 targetLineId = tgtLine,
+                                targetLineIndex = tgtLineIndex,
                                 connectionType = forwardType
                             )
                         )
@@ -150,6 +153,7 @@ internal class SefariaLinksImporter(
                                 targetBookId = srcBookId,
                                 sourceLineId = tgtLine,
                                 targetLineId = srcLine,
+                                targetLineIndex = srcLineIndex,
                                 connectionType = reverseType
                             )
                         )


### PR DESCRIPTION
## Summary

- **Bug**: commentary segments on a single source line (e.g. Bartenura on a Mishna) were returned in SQLite insertion order because every link query tied-sorted on `book.orderIndex` alone, which is constant across all segments of the same commentator. Users saw the Bartenura for the beginning of a Mishna appear at the end of the commentary panel (see kdroidFilter/Zayit#415).
- **Fix**: add a denormalized `link.targetLineIndex` column mirroring `line.lineIndex` of the target (+ composite index `idx_link_type_source_order`). Every commentary query now uses it as the secondary sort key (`ORDER BY b.orderIndex, l.targetLineIndex`). Importers (Sefaria, Otzaria, transitive Havrouta SQL) populate the column at insert time.
- **Regression test** locked in `SeforimRepositoryIntegrationTest`: inserts links in shuffled order, asserts production query returns them sorted by target line index.
- **DB regenerated end-to-end** (`:generateSeforimDb`, 9m 8s). E2E SQL validation confirms 7.77M links populated, 100% consistency with `line.lineIndex`, and the reference case (Mishna Avot 3:16 Bartenura) now returns segments in strict ascending order 250→262.

## Schema change

Adds `targetLineIndex INTEGER NOT NULL` to `link` and `idx_link_type_source_order(connectionTypeId, sourceLineId, targetLineIndex)`. **Requires a full DB regeneration** — no in-place migration since the pack is redistributed as a release artifact.

## Test plan

- [x] Unit/integration: `./gradlew :dao:jvmTest` — new regression test passes.
- [x] Full pipeline: `./gradlew :generateSeforimDb` completes clean (9m 8s).
- [x] E2E SQL: schema / index presence, `targetLineIndex` populated on 7.77M rows, `line.lineIndex` cross-check matches, Avot 3:16 Bartenura returns 250→262 strictly monotonic.
- [ ] Desktop smoke test covered by the matching Zayit PR (bumps submodule + `MINIMUM_REQUIRED_VERSION`).