### PR TITLE
fix(generator): don't abort the build on unmatched generation titles

### DIFF
--- a/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SeedGenerationsPostProcess.kt
+++ b/generator/sefariasqlite/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/sefariasqlite/SeedGenerationsPostProcess.kt
@@ -150,9 +150,14 @@ private fun applyGenerations(
             linksCreated += linkStmt.executeUpdate()
         }
     }
-    require(unmatchedTitles.isEmpty()) {
-        "Generation CSV has ${unmatchedTitles.size} unmatched book title(s): " +
-            unmatchedTitles.take(20).joinToString()
+    // Don't abort the whole build when generations.csv references books that are
+    // not in the current library (upstream otzaria-library vs ForDB drift): keep
+    // every link that DID match and just warn about the rest.
+    if (unmatchedTitles.isNotEmpty()) {
+        logger.w {
+            "Generation CSV has ${unmatchedTitles.size} unmatched book title(s) (skipped): " +
+                unmatchedTitles.take(20).joinToString()
+        }
     }
     return GenerationApplyResult(generationsCreated, linksCreated, 0)
 }


### PR DESCRIPTION
## Summary
`seedGenerations` aborted the entire `generateSeforimDb` pipeline via `require(unmatchedTitles.isEmpty())` whenever `generations.csv` (ForDB) referenced a book title that isn't in the current `otzaria-library`. The two sources are fetched independently ("latest"), so any upstream drift (a renamed/removed book) hard-fails the whole build — e.g. *"Generation CSV has 37 unmatched book title(s): מעדני יום טוב על ברכות, …"*.

This keeps every generation link that **did** match and logs a warning for the unmatched ones instead of throwing.

- `require(unmatchedTitles.isEmpty())` → `if (unmatchedTitles.isNotEmpty()) logger.w { … }`
- Behaviour unchanged when sources are consistent (0 unmatched → no warning).

## Test plan
- [x] `generateSeforimDb` completes when `generations.csv` references missing books (warns, doesn't abort).
- [x] Generation links for matched titles are still created (`book_generation` populated).
- [x] No regression when sources are in sync.