### PR TITLE
ci(release): skip delta production when DB schema changes

### DIFF
--- a/.github/workflows/manual-generate-release.yml
+++ b/.github/workflows/manual-generate-release.yml
@@ -204,6 +204,22 @@ jobs:
             PREV_DB=$(find prev-dbs/extract -name seforim.db -type f | head -n1)
             test -s "$PREV_DB" || { echo "::error::seforim.db not found in bundle of $TAG"; exit 1; }
 
+            # Skip the delta whenever the schema changed: a delta can only carry
+            # data (upserts/deletes), not schema migrations. If prev and new
+            # don't have identical table/index DDL, clients on $TARGET_VER must
+            # re-download the full bundle — so we don't produce (or fail CI on)
+            # a patch for this offset.
+            schema_of() {
+              sqlite3 "$1" \
+                "SELECT sql FROM sqlite_master WHERE type IN ('table','index') AND sql IS NOT NULL ORDER BY name;" \
+                | tr -s '[:space:]' ' '
+            }
+            if [ "$(schema_of "$PREV_DB")" != "$(schema_of "$PWD/build/seforim.db")" ]; then
+              echo "::notice::Schema differs v${TARGET_VER} → v${THIS_VER} — skipping delta, clients fall back to full bundle"
+              rm -rf prev-dbs
+              continue
+            fi
+
             ./gradlew :generator-common:producePatchAndVerify \
               -PprevDb=$PWD/$PREV_DB \
               -PnewDb=$PWD/build/seforim.db \


### PR DESCRIPTION
## Summary

- A delta patch can only carry **data** (upserts/deletes), not schema migrations. When the prev and new `seforim.db` have different table/index DDL, the producer fails or produces a hash-mismatch.
- The patch-fan step now compares the prev vs new schema (`sqlite_master` DDL) before invoking the producer, and **skips that offset** on any difference.
- Clients on the affected version simply fall back to the **full bundle** — the manifest's native behavior when no covering delta exists.
- **Stable IDs** are untouched (the "Seed allocator" step runs regardless).

Net effect:
- schema changed → full re-download, no delta
- schema unchanged → delta as before
- CI never fails on a schema change, and no migration logic is needed in the producer

This makes the `ADD COLUMN` migration approach (PR #84) unnecessary.
