### PR TITLE
feat(search): expose isBaseBook on LineHit

### DIFF
--- a/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/LuceneSearchEngine.kt
+++ b/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/LuceneSearchEngine.kt
@@ -558,7 +558,8 @@ class LuceneSearchEngine(
                 lineIndex = meta.lineIndex,
                 snippet = snippet,
                 score = boostedScore,
-                rawText = raw
+                rawText = raw,
+                isBaseBook = meta.isBaseBook
             )
         }
         // Re-sort by boosted score (descending)

--- a/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/SearchSession.kt
+++ b/search/src/jvmMain/kotlin/io/github/kdroidfilter/seforimlibrary/search/SearchSession.kt
@@ -62,6 +62,8 @@ data class SearchPage(
  * @property snippet HTML snippet with highlighted matching terms (contains `<b>` tags)
  * @property score Relevance score (higher = more relevant). Includes boosts for base books.
  * @property rawText Original unprocessed text content of the line
+ * @property isBaseBook True if the line belongs to a base book (vs a commentary). Lets callers
+ *   correlate results: anchor each hit on its base line and nest matching commentaries under it.
  */
 data class LineHit(
     val bookId: Long,
@@ -70,7 +72,8 @@ data class LineHit(
     val lineIndex: Int,
     val snippet: String,
     val score: Float,
-    val rawText: String
+    val rawText: String,
+    val isBaseBook: Boolean = false
 )
 
 /**


### PR DESCRIPTION
## Summary
- Add `isBaseBook: Boolean` to `LineHit`, populated from the already-indexed/stored `is_base_book` field (no DB or index regeneration needed).
- Lets the app correlate search results: anchor each hit on its base line and nest matching commentaries under it (upcoming search-results redesign).
- Defaults to `false` for source-compat with `LineHit`s built outside the Lucene engine (the dense-hit factory sets it explicitly app-side).

## Test plan
- [x] `:search` compiles
- [ ] Consumed by the Zayit search redesign PR